### PR TITLE
Apple sign in

### DIFF
--- a/Auth/Auth.csproj
+++ b/Auth/Auth.csproj
@@ -17,10 +17,12 @@
       <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
       <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.3.0" />
+      <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="8.12.1" />
+      <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.12.1" />
       <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="7.3.1" />
       <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="7.3.1" />
       <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.3.1" />
-      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.1" />
+      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Auth/AuthController.cs
+++ b/Auth/AuthController.cs
@@ -140,7 +140,11 @@ public class AuthController : ControllerBase
     {
         var jwtToken = await ValidateAppleIdTokenAsync(req.IdToken);
         if (jwtToken is null)
-            return Unauthorized("Invalid ID token");
+        {
+            Logger.Log($"The ID token is : {req.IdToken}", LogLevel.Information);
+            return Unauthorized("Invalid ID token"); 
+        }
+            
 
         string email = jwtToken.Claims.First(c => c.Type == "email").Value;
         bool exists = await repo.ExistsAsync(email);

--- a/Auth/AuthController.cs
+++ b/Auth/AuthController.cs
@@ -144,14 +144,19 @@ public class AuthController : ControllerBase
         {
             return Unauthorized("Invalid ID token"); 
         }
-        
 
-        string appleId = jwtToken.Claims.First(c => c.Type == "userIdentifer").Value;
+
+        string? appleId = req.userIdentifier;
+        if (appleId is null) return BadRequest("UserIdentifier is null");
         bool exists = await repo.ExistsAppleAsync(appleId);
-        string email = jwtToken.Claims.First(c => c.Type == "email").Value;
+        string? email = req.email;
         
         if (!exists)
         {
+            if (email is null || email == "")
+            {
+                return BadRequest("Email is required for first-time Apple sign-in");
+            }
             // Treat as first‑time Apple sign‑in (sign‑up)
             string jwt = jwtService.GenerateToken(email);
             Logger.Log($"User '{email}' sign up via Apple jwt sent successfully");
@@ -342,5 +347,3 @@ public class AuthController : ControllerBase
         }
     }
 }
-
-public record AppleAuthRequest(string IdToken);

--- a/Auth/AuthController.cs
+++ b/Auth/AuthController.cs
@@ -139,12 +139,12 @@ public class AuthController : ControllerBase
         [FromServices] UsersRepository repo)
     {
         var jwtToken = await ValidateAppleIdTokenAsync(req.IdToken);
+        Logger.Log($"The ID token is : {req.IdToken}", LogLevel.Information);
         if (jwtToken is null)
         {
-            Logger.Log($"The ID token is : {req.IdToken}", LogLevel.Information);
             return Unauthorized("Invalid ID token"); 
         }
-            
+        
 
         string appleId = jwtToken.Claims.First(c => c.Type == "userIdentifer").Value;
         bool exists = await repo.ExistsAppleAsync(appleId);

--- a/Auth/AuthController.cs
+++ b/Auth/AuthController.cs
@@ -24,6 +24,12 @@ using Shared.Extensions;
 using Shared.Logging;
 using Shared.Models.Database;
 using Shared.Models.Requests.Auth;
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using System.Security.Cryptography;
+using System.Security.Claims;
 
 namespace Auth;
 
@@ -37,6 +43,7 @@ public class AuthController : ControllerBase
     private string _iosId => _configuration["Auth:Google:Ios"] ?? throw new NullReferenceException();
     private string _webId => _configuration["Auth:Google:Web"] ?? throw new NullReferenceException();
     private string _webSecret => _configuration["Auth:Google:WebSecret"] ?? throw new NullReferenceException();
+    private string _appleClientId => _configuration["Auth:Apple:ClientId"] ?? throw new NullReferenceException();
 
     public AuthController(IConfiguration configuration)
     {
@@ -124,6 +131,48 @@ public class AuthController : ControllerBase
         Logger.Log($"User '{email}' logged in successfully via google'");
         
         return Ok(jwt);
+    }
+
+    [HttpPost("apple")]
+    public async Task<IActionResult> LoginViaApple([FromBody] AppleAuthRequest req,
+        [FromServices] JwtService jwtService,
+        [FromServices] UsersRepository repo)
+    {
+        var jwtToken = await ValidateAppleIdTokenAsync(req.IdToken);
+        if (jwtToken is null)
+            return Unauthorized("Invalid ID token");
+
+        string email = jwtToken.Claims.First(c => c.Type == "email").Value;
+        bool exists = await repo.ExistsAsync(email);
+
+        if (!exists)
+        {
+            // Treat as first‑time Apple sign‑in (sign‑up)
+            string jwt = jwtService.GenerateToken(email);
+            Logger.Log($"User '{email}' sign up via Apple jwt sent successfully");
+
+            return Ok(new
+            {
+                jwt,
+                firstName = jwtToken.Claims.FirstOrDefault(c => c.Type == "given_name")?.Value,
+                lastName  = jwtToken.Claims.FirstOrDefault(c => c.Type == "family_name")?.Value,
+                email = jwtToken.Claims.FirstOrDefault(c => c.Type == "email")?.Value,
+            });
+        }
+        else
+        {
+            UserModel user = (await repo.GetUserByEmailAsync(email))!;
+
+            if (user.IsEmailVerified.HasValue && !user.IsEmailVerified.Value || !user.IsEmailVerified.HasValue)
+            {
+                user.IsEmailVerified = true;
+            }
+
+            string jwt = jwtService.GenerateToken(email);
+            Logger.Log($"User '{email}' logged in successfully via Apple");
+
+            return Ok(jwt);
+        }
     }
 
     [HttpPost("login")]
@@ -238,4 +287,37 @@ public class AuthController : ControllerBase
             return null;
         }
     }
+
+    private async Task<JwtSecurityToken?> ValidateAppleIdTokenAsync(string idToken)
+    {
+        try
+        {
+            // Fetch Apple's OpenID configuration (keys are rotated; cache in production)
+            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                "https://appleid.apple.com/.well-known/openid-configuration",
+                new OpenIdConnectConfigurationRetriever());
+
+            var oidcConfig = await configurationManager.GetConfigurationAsync();
+            var validationParameters = new TokenValidationParameters
+            {
+                ValidIssuer         = "https://appleid.apple.com",
+                ValidAudience       = _appleClientId,
+                IssuerSigningKeys   = oidcConfig.SigningKeys,
+                ValidateLifetime    = true
+            };
+
+            var handler = new JwtSecurityTokenHandler();
+            handler.InboundClaimTypeMap.Clear(); // keep original claim names
+            _ = handler.ValidateToken(idToken, validationParameters, out SecurityToken validatedToken);
+
+            return (JwtSecurityToken)validatedToken;
+        }
+        catch (Exception e)
+        {
+            Logger.Log($"Failed to validate Apple ID token: {e.Message}", LogLevel.Error);
+            return null;
+        }
+    }
 }
+
+public record AppleAuthRequest(string IdToken);

--- a/Shared/Models/Requests/Auth/AppleAuthRequest.cs
+++ b/Shared/Models/Requests/Auth/AppleAuthRequest.cs
@@ -1,0 +1,10 @@
+namespace Shared.Models.Requests.Auth;
+
+public class AppleAuthRequest
+{
+    public string? IdToken { get; set; }
+    public string? email { get; set; }
+    public string? givenName { get; set; }
+    public string? familyName { get; set; }
+    public string? userIdentifier { get; set; }
+}

--- a/Shared/Models/Requests/Auth/SignUpRequest.cs
+++ b/Shared/Models/Requests/Auth/SignUpRequest.cs
@@ -32,4 +32,6 @@ public class SignUpRequest
     public string? City { get; set; }
 
     public bool Consent { get; set; }
+    
+    public string? AppleId { get; set; }
 }


### PR DESCRIPTION
This pull request adds support for Apple Sign-In authentication to the project, including backend validation of Apple ID tokens, updates to the user repository for storing Apple IDs, and necessary model and configuration changes. It also updates some package dependencies to ensure compatibility with the new authentication flow.

### Apple Sign-In Integration

* Added a new endpoint `LoginViaApple` in `AuthController` to handle Apple authentication, including token validation, user lookup/creation, and JWT issuance.
* Implemented `ValidateAppleIdTokenAsync` in `AuthController` to securely validate Apple ID tokens using Apple's OpenID Connect configuration and signing keys.
* Added `AppleAuthRequest` model to represent incoming Apple authentication requests.

### User Repository Enhancements

* Added methods to `UsersRepository` for checking existence of Apple IDs, retrieving users by Apple ID, and associating Apple IDs with users. [[1]](diffhunk://#diff-35685012c46fa0d01bc58a7fa7b576a829eb3d0257c9e205c44b449a916d2e25R41-R47) [[2]](diffhunk://#diff-35685012c46fa0d01bc58a7fa7b576a829eb3d0257c9e205c44b449a916d2e25R141-R153) [[3]](diffhunk://#diff-35685012c46fa0d01bc58a7fa7b576a829eb3d0257c9e205c44b449a916d2e25R244-R253)
* Updated user creation logic to store `appleid` in the database when available, and updated the `SignUpRequest` model to include an optional `AppleId` field. [[1]](diffhunk://#diff-35685012c46fa0d01bc58a7fa7b576a829eb3d0257c9e205c44b449a916d2e25L83-R91) [[2]](diffhunk://#diff-35685012c46fa0d01bc58a7fa7b576a829eb3d0257c9e205c44b449a916d2e25L103-R111) [[3]](diffhunk://#diff-a8502ca64f610b8d8f56c9f3ee421e3f9b4b6bf5974b4534203983dc1c445c9bR35-R36)

### Dependency and Configuration Updates

* Added required NuGet packages for OpenID Connect and token validation, and updated `System.IdentityModel.Tokens.Jwt` to a compatible version.
* Added retrieval of Apple client ID from configuration in `AuthController`.