### PR TITLE
Fix OpenAPI articles category deletion path

### DIFF
--- a/Articles/ArticlesController.cs
+++ b/Articles/ArticlesController.cs
@@ -261,7 +261,7 @@ public class ArticlesController : ControllerBase
         return success ? Ok() : StatusCode(500, "Failed to delete category");
     }
 
-    [HttpDelete("{categoryName}/{articleId:int}")]
+    [HttpDelete("categories/{categoryName}/{articleId:int}")]
     public async Task<IActionResult> DeleteCategory([FromRoute] string categoryName, 
         [FromRoute] int articleId, 
         [FromServices] JwtService jwtService,

--- a/StrnadiAPI-openapi.yaml
+++ b/StrnadiAPI-openapi.yaml
@@ -1536,7 +1536,7 @@ paths:
             text/plain:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /articles/{categoryName}/{articleId}:
+  /articles/categories/{categoryName}/{articleId}:
     delete:
       tags: [Articles]
       summary: Remove an article from a category


### PR DESCRIPTION
## Summary
- update the articles controller category deletion route to use the categories prefix
- align the embedded OpenAPI specification with the adjusted route so the document validates

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e82b84fc832c880562b786269087