### PR TITLE
Update OpenAPI generation to use XML-documented controllers

### DIFF
--- a/Achievements/AchievementsController.cs
+++ b/Achievements/AchievementsController.cs
@@ -4,15 +4,28 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Repository;
 using Shared.Extensions;
+using Shared.Models.Database.Achievements;
 using Shared.Models.Requests.Achievements;
 
 namespace Achievements;
 
+/// <summary>
+/// Handles achievement listing, image retrieval, and administrative creation.
+/// </summary>
 [ApiController]
 [Route("achievements")]
 public class AchievementsController : ControllerBase
 {
+    /// <summary>
+    /// Gets all achievements or the achievements awarded to a specific user.
+    /// </summary>
+    /// <param name="userId">Optional user identifier used to filter awarded achievements.</param>
+    /// <param name="repo">Repository used to query and award achievements.</param>
+    /// <returns>The matching achievements.</returns>
     [HttpGet]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(Achievement[]), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> Get([FromQuery] int? userId, [FromServices] AchievementsRepository repo)
     {
         if (userId is not null)
@@ -26,7 +39,16 @@ public class AchievementsController : ControllerBase
         return Ok(achievements);
     }
 
+    /// <summary>
+    /// Gets the PNG image for an achievement.
+    /// </summary>
+    /// <param name="achievementId">Achievement identifier.</param>
+    /// <param name="repo">Repository used to read the achievement image.</param>
+    /// <returns>The achievement image file.</returns>
     [HttpGet("{achievementId:int}/photo")]
+    [Produces("image/png")]
+    [ProducesResponseType(typeof(FileContentResult), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetPhotoAsync([FromRoute] int achievementId, [FromServices] AchievementsRepository repo)
     {
         byte[]? content = await repo.GetPhotoAsync(achievementId);
@@ -34,8 +56,22 @@ public class AchievementsController : ControllerBase
         return File(content, "image/png");
     }
 
+    /// <summary>
+    /// Creates an achievement with localized content and an image.
+    /// </summary>
+    /// <param name="sql">SQL query used to determine which users receive the achievement.</param>
+    /// <param name="contents">JSON array of localized achievement content entries.</param>
+    /// <param name="file">Achievement image file.</param>
+    /// <param name="jwtService">JWT validation service.</param>
+    /// <param name="usersRepo">Repository used to verify administrator access.</param>
+    /// <param name="achievementsRepo">Repository used to create the achievement.</param>
+    /// <returns>An HTTP result indicating whether the achievement was created.</returns>
     [HttpPost]
     [RequestSizeLimit(int.MaxValue)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> Post(
         [FromForm] string sql,
         [FromForm] string contents,

--- a/Articles/ArticlesController.cs
+++ b/Articles/ArticlesController.cs
@@ -1,18 +1,31 @@
 ﻿using Auth.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Repository;
 using Shared.Extensions;
 using Shared.Logging;
+using Shared.Models.Database.Articles;
 using Shared.Models.Requests.Articles;
 using Shared.Tools;
 
 namespace Articles;
 
+/// <summary>
+/// Provides endpoints for reading, creating, updating, categorizing, and deleting articles and article attachments.
+/// </summary>
 [ApiController]
 [Route("articles")]
 public class ArticlesController : ControllerBase
 {
+    /// <summary>
+    /// Gets all articles with their attachments and categories.
+    /// </summary>
+    /// <param name="articlesRepo">Repository used to read article data.</param>
+    /// <returns>An article collection, no content when no articles exist, or an error response.</returns>
     [HttpGet]
+    [ProducesResponseType(typeof(Article[]), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Get([FromServices] ArticlesRepository articlesRepo)
     {
         var articles = await articlesRepo.GetAsync();
@@ -25,7 +38,16 @@ public class ArticlesController : ControllerBase
         return Ok(articles);
     }
 
+    /// <summary>
+    /// Gets article categories, optionally including articles assigned to each category.
+    /// </summary>
+    /// <param name="articlesRepo">Repository used to read category data.</param>
+    /// <param name="articles">Whether to include assigned articles in each category.</param>
+    /// <returns>A category collection, no content when no categories exist, or an error response.</returns>
     [HttpGet("categories")]
+    [ProducesResponseType(typeof(ArticleCategory[]), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetCategories([FromServices] ArticlesRepository articlesRepo,
         [FromQuery] bool articles = true)
     {
@@ -42,7 +64,15 @@ public class ArticlesController : ControllerBase
         return Ok(categories);
     }
 
+    /// <summary>
+    /// Gets articles assigned to a category by category name.
+    /// </summary>
+    /// <param name="categoryName">The category name to query.</param>
+    /// <param name="articlesRepo">Repository used to read article data.</param>
+    /// <returns>The category article collection or an error response.</returns>
     [HttpGet("{categoryName}")]
+    [ProducesResponseType(typeof(Article[]), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Get([FromRoute] string categoryName,
         [FromServices] ArticlesRepository articlesRepo)
     {
@@ -53,7 +83,15 @@ public class ArticlesController : ControllerBase
         return Ok(article);
     }
     
+    /// <summary>
+    /// Gets an article by id with its attachments and categories.
+    /// </summary>
+    /// <param name="articlesRepo">Repository used to read article data.</param>
+    /// <param name="id">The article id.</param>
+    /// <returns>The article or an error response.</returns>
     [HttpGet("{id:int}")]
+    [ProducesResponseType(typeof(Article), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Get([FromServices] ArticlesRepository articlesRepo, [FromRoute] int id)
     {
         var article = await articlesRepo.GetAsync(id);
@@ -63,7 +101,16 @@ public class ArticlesController : ControllerBase
         return Ok(article);
     }
 
+    /// <summary>
+    /// Gets an article attachment file by article id and file name.
+    /// </summary>
+    /// <param name="articlesRepo">Repository used to read article attachment data.</param>
+    /// <param name="id">The article id.</param>
+    /// <param name="fileName">The attachment file name.</param>
+    /// <returns>The attachment file or a not found response.</returns>
     [HttpGet("{id:int}/{fileName}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Get([FromServices] ArticlesRepository articlesRepo, 
         [FromRoute] int id,
         [FromRoute] string fileName)
@@ -83,7 +130,18 @@ public class ArticlesController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Creates an article.
+    /// </summary>
+    /// <param name="req">The article data to save.</param>
+    /// <param name="jwtService">Service used to validate the JWT from the request.</param>
+    /// <param name="articlesRepo">Repository used to save article data.</param>
+    /// <returns>The created article id or an error response.</returns>
     [HttpPost]
+    [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Post([FromBody] ArticleUploadRequest req,
         [FromServices] JwtService jwtService,
         [FromServices] ArticlesRepository articlesRepo)
@@ -101,7 +159,20 @@ public class ArticlesController : ControllerBase
         return id is not null ? Ok(id) : StatusCode(500, "Failed to save article");
     }
 
+    /// <summary>
+    /// Saves an attachment file for an article.
+    /// </summary>
+    /// <param name="id">The article id.</param>
+    /// <param name="fileName">The attachment file name.</param>
+    /// <param name="base64">The attachment content encoded as Base64.</param>
+    /// <param name="jwtService">Service used to validate the JWT from the request.</param>
+    /// <param name="articlesRepo">Repository used to save article attachment data.</param>
+    /// <returns>An ok response when the attachment is saved or an error response.</returns>
     [HttpPost("{id:int}/{fileName}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Post([FromRoute] int id,
         [FromRoute] string fileName,
         [FromBody] string base64,
@@ -121,7 +192,19 @@ public class ArticlesController : ControllerBase
         return success ? Ok() : StatusCode(500, "Failed to save article");
     }
 
+    /// <summary>
+    /// Creates an article category.
+    /// </summary>
+    /// <param name="req">The category data to save.</param>
+    /// <param name="articlesRepo">Repository used to save article category data.</param>
+    /// <param name="usersRepo">Repository used to verify administrator access.</param>
+    /// <param name="jwtService">Service used to validate the JWT from the request.</param>
+    /// <returns>An ok response when the category is saved or an error response.</returns>
     [HttpPost("categories")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> PostCategories([FromBody] ArticleCategoryUploadRequest req,
         [FromServices] ArticlesRepository articlesRepo,
         [FromServices] UsersRepository usersRepo,
@@ -143,7 +226,19 @@ public class ArticlesController : ControllerBase
         return success ? Ok() : StatusCode(500, "Failed to save article category");
     }
 
+    /// <summary>
+    /// Updates an article by id.
+    /// </summary>
+    /// <param name="id">The article id.</param>
+    /// <param name="req">The article fields to update.</param>
+    /// <param name="jwtService">Service used to validate the JWT from the request.</param>
+    /// <param name="articlesRepo">Repository used to update article data.</param>
+    /// <returns>An ok response when the article is updated or an error response.</returns>
     [HttpPatch("{id:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Patch([FromRoute] int id, 
         [FromBody] ArticleUpdateRequest req,
         [FromServices] JwtService jwtService,
@@ -162,7 +257,21 @@ public class ArticlesController : ControllerBase
         return success ? Ok() : StatusCode(500, "Failed to save article");
     }
 
+    /// <summary>
+    /// Updates an article attachment file.
+    /// </summary>
+    /// <param name="id">The article id.</param>
+    /// <param name="fileName">The attachment file name.</param>
+    /// <param name="base64">The replacement attachment content encoded as Base64.</param>
+    /// <param name="jwtService">Service used to validate the JWT from the request.</param>
+    /// <param name="usersRepo">Repository used to verify administrator access.</param>
+    /// <param name="articlesRepo">Repository used to update article attachment data.</param>
+    /// <returns>An ok response when the attachment is updated or an error response.</returns>
     [HttpPatch("{id:int}/{fileName}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Patch([FromRoute] int id,
         [FromRoute] string fileName,
         [FromBody] string base64,
@@ -186,7 +295,20 @@ public class ArticlesController : ControllerBase
         return success ? Ok() : StatusCode(500, "Failed to save article");
     }
 
+    /// <summary>
+    /// Assigns an article to a category.
+    /// </summary>
+    /// <param name="categoryName">The category name.</param>
+    /// <param name="request">The article assignment data.</param>
+    /// <param name="articlesRepo">Repository used to save the category assignment.</param>
+    /// <param name="usersRepo">Repository used to verify administrator access.</param>
+    /// <param name="jwtService">Service used to validate the JWT from the request.</param>
+    /// <returns>An ok response when the assignment is saved or an error response.</returns>
     [HttpPatch("{categoryName}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> AssignArticleToCategory([FromRoute] string categoryName, 
         [FromBody] AssignArticleToCategoryRequest request,
         [FromServices] ArticlesRepository articlesRepo,
@@ -209,7 +331,18 @@ public class ArticlesController : ControllerBase
         return success ? Ok() : StatusCode(500, "Failed to save article");
     }
 
+    /// <summary>
+    /// Deletes an article by id.
+    /// </summary>
+    /// <param name="id">The article id.</param>
+    /// <param name="jwtService">Service used to validate the JWT from the request.</param>
+    /// <param name="articlesRepo">Repository used to delete article data.</param>
+    /// <returns>An ok response when the article is deleted or an error response.</returns>
     [HttpDelete("{id:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Delete([FromRoute] int id,
         [FromServices] JwtService jwtService,
         [FromServices] ArticlesRepository articlesRepo)
@@ -227,7 +360,19 @@ public class ArticlesController : ControllerBase
         return success ? Ok() : StatusCode(500, "Failed to save article");
     }
 
+    /// <summary>
+    /// Deletes an article attachment file.
+    /// </summary>
+    /// <param name="id">The article id.</param>
+    /// <param name="fileName">The attachment file name.</param>
+    /// <param name="jwtService">Service used to validate the JWT from the request.</param>
+    /// <param name="articlesRepo">Repository used to delete article attachment data.</param>
+    /// <returns>An ok response when the attachment is deleted or an error response.</returns>
     [HttpDelete("{id:int}/{fileName}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Delete([FromRoute] int id, [FromRoute] string fileName,
         [FromServices] JwtService jwtService,
         [FromServices] ArticlesRepository articlesRepo)
@@ -245,7 +390,19 @@ public class ArticlesController : ControllerBase
         return success ? Ok() : StatusCode(500, "Failed to save article");
     }
 
+    /// <summary>
+    /// Deletes an article category by category name.
+    /// </summary>
+    /// <param name="categoryName">The category name.</param>
+    /// <param name="jwtService">Service used to validate the JWT from the request.</param>
+    /// <param name="usersRepo">Repository used to verify administrator access.</param>
+    /// <param name="articlesRepo">Repository used to delete article category data.</param>
+    /// <returns>An ok response when the category is deleted or an error response.</returns>
     [HttpDelete("categories/{categoryName}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> DeleteCategory([FromRoute] string categoryName,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo,
@@ -271,7 +428,20 @@ public class ArticlesController : ControllerBase
         return success ? Ok() : StatusCode(500, "Failed to delete category");
     }
 
+    /// <summary>
+    /// Removes an article from a category.
+    /// </summary>
+    /// <param name="categoryName">The category name.</param>
+    /// <param name="articleId">The article id.</param>
+    /// <param name="jwtService">Service used to validate the JWT from the request.</param>
+    /// <param name="usersRepo">Repository used to verify administrator access.</param>
+    /// <param name="articlesRepo">Repository used to delete the category assignment.</param>
+    /// <returns>An ok response when the assignment is deleted or an error response.</returns>
     [HttpDelete("categories/{categoryName}/{articleId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> DeleteCategory([FromRoute] string categoryName, 
         [FromRoute] int articleId, 
         [FromServices] JwtService jwtService,

--- a/Auth/AuthController.cs
+++ b/Auth/AuthController.cs
@@ -26,6 +26,7 @@ using Shared.Models.Database;
 using Shared.Models.Requests.Auth;
 using System.IdentityModel.Tokens.Jwt;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -33,6 +34,9 @@ using LogLevel = Shared.Logging.LogLevel;
 
 namespace Auth;
 
+/// <summary>
+/// Provides authentication endpoints for JWT, password, Google, and Apple sign-in flows.
+/// </summary>
 [ApiController]
 [Route("/auth")]
 public class AuthController : ControllerBase
@@ -46,12 +50,25 @@ public class AuthController : ControllerBase
     private string _appleClientId => _configuration["Auth:Apple:ClientId"] ?? throw new NullReferenceException();
     private string _appleClientIdWeb => _configuration["Auth:Apple:ClientIdWeb"] ?? throw new NullReferenceException();
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthController"/> class.
+    /// </summary>
+    /// <param name="configuration">Application configuration containing authentication settings.</param>
     public AuthController(IConfiguration configuration)
     {
         _configuration = configuration;
     }
 
+    /// <summary>
+    /// Verifies that the current JWT contains an email address for a verified user.
+    /// </summary>
+    /// <param name="jwtService">Service used to read the JWT email claim.</param>
+    /// <param name="usersRepo">Repository used to check email verification state.</param>
+    /// <returns>An HTTP result indicating whether the JWT belongs to a verified user.</returns>
     [HttpGet("verify-jwt")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> VerifyJwt([FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo)
     {
@@ -68,7 +85,16 @@ public class AuthController : ControllerBase
         return await usersRepo.IsEmailVerifiedAsync(email) ? Ok() : StatusCode(403);
     }
 
+    /// <summary>
+    /// Renews a valid JWT for an existing user.
+    /// </summary>
+    /// <param name="jwtService">Service used to validate and generate JWT values.</param>
+    /// <param name="usersRepo">Repository used to check that the JWT user exists.</param>
+    /// <returns>An HTTP result containing a renewed JWT when the current token is valid.</returns>
     [HttpGet("renew-jwt")]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> RenewJwt([FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo)
     {
@@ -88,7 +114,17 @@ public class AuthController : ControllerBase
         return Ok(newJwt);
     }
     
+    /// <summary>
+    /// Starts a new account sign-up using a Google ID token.
+    /// </summary>
+    /// <param name="req">Google authentication request containing the ID token.</param>
+    /// <param name="jwtService">Service used to generate an application JWT.</param>
+    /// <param name="repo">Repository used to check existing users.</param>
+    /// <returns>An HTTP result containing a JWT and Google profile names for a new user.</returns>
     [HttpPost("sign-up-google")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> SignUpViaGoogle([FromBody] GoogleAuthRequest req,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository repo)
@@ -108,7 +144,17 @@ public class AuthController : ControllerBase
         return Ok(new { jwt, firstName = payload.GivenName, lastName = payload.FamilyName });
     }
 
+    /// <summary>
+    /// Logs an existing user in using a Google ID token.
+    /// </summary>
+    /// <param name="req">Google authentication request containing the ID token.</param>
+    /// <param name="jwtService">Service used to generate an application JWT.</param>
+    /// <param name="repo">Repository used to load the matching user.</param>
+    /// <returns>An HTTP result containing a JWT for an existing user.</returns>
     [HttpPost("login-google")]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> LoginViaGoogle([FromBody] GoogleAuthRequest req,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository repo)
@@ -134,7 +180,16 @@ public class AuthController : ControllerBase
         return Ok(jwt);
     }
 
+    /// <summary>
+    /// Handles Google authentication for linking, login, or sign-up discovery.
+    /// </summary>
+    /// <param name="req">Google authentication request containing the ID token.</param>
+    /// <param name="jwtService">Service used to validate existing auth JWTs and generate new JWTs.</param>
+    /// <param name="repo">Repository used to load and update Google user mappings.</param>
+    /// <returns>An HTTP result describing whether the Google user exists or was linked.</returns>
     [HttpPost("google")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> GoogleAuth([FromBody] GoogleAuthRequest req,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository repo)
@@ -197,7 +252,17 @@ public class AuthController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Handles Apple authentication for linking, login, or sign-up discovery.
+    /// </summary>
+    /// <param name="req">Apple authentication request containing the ID token and optional user details.</param>
+    /// <param name="jwtService">Service used to validate existing auth JWTs and generate new JWTs.</param>
+    /// <param name="repo">Repository used to load and update Apple user mappings.</param>
+    /// <returns>An HTTP result containing login or first-time Apple sign-in details.</returns>
     [HttpPost("apple")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> LoginViaApple([FromBody] AppleAuthRequest req,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository repo)
@@ -302,7 +367,16 @@ public class AuthController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Receives the web Apple callback and redirects the browser back to the provided state return URL.
+    /// </summary>
+    /// <param name="user">Apple user payload posted by Apple, when provided.</param>
+    /// <param name="state">State value containing the return URL.</param>
+    /// <param name="idToken">Apple ID token posted by Apple.</param>
+    /// <returns>A redirect to the return URL when state is provided, otherwise a bad request response.</returns>
     [HttpPost("apple-callback")]
+    [ProducesResponseType(StatusCodes.Status302Found)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public IActionResult AppleCallback(
         [FromForm] string? user,
         [FromForm] string? state,
@@ -321,7 +395,16 @@ public class AuthController : ControllerBase
         }
     }
     
+    /// <summary>
+    /// Receives the app Apple callback and redirects into the Android application intent URL.
+    /// </summary>
+    /// <param name="user">Apple user payload posted by Apple, when provided.</param>
+    /// <param name="state">State value posted by Apple, when provided.</param>
+    /// <param name="idToken">Apple ID token posted by Apple, when provided.</param>
+    /// <param name="code">Apple authorization code posted by Apple, when provided.</param>
+    /// <returns>A redirect to the Android intent callback URL.</returns>
     [HttpPost("apple/callback")]
+    [ProducesResponseType(StatusCodes.Status302Found)]
     public IActionResult AppleAppCallback(
         [FromForm] string? user,
         [FromForm] string? state,
@@ -346,21 +429,47 @@ public class AuthController : ControllerBase
         return Redirect(intentUrl);
     }
 
+    /// <summary>
+    /// Checks whether a user has an Apple identifier linked.
+    /// </summary>
+    /// <param name="userId">Identifier of the user to inspect.</param>
+    /// <param name="users">Repository used to load the user.</param>
+    /// <returns>An HTTP result indicating whether the user has an Apple identifier.</returns>
     [HttpGet("has-apple-id")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> HasAppleId([FromQuery] int userId, [FromServices] UsersRepository users)
     {
         var has = (await users.GetUserByIdAsync(userId))?.AppleId is not null;
         return has ? Ok() : Conflict();
     }
 
+    /// <summary>
+    /// Checks whether a user has a Google identifier linked.
+    /// </summary>
+    /// <param name="userId">Identifier of the user to inspect.</param>
+    /// <param name="users">Repository used to load the user.</param>
+    /// <returns>An HTTP result indicating whether the user has a Google identifier.</returns>
     [HttpGet("has-google-id")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> HasGoogleId([FromQuery] int userId, [FromServices] UsersRepository users)
     {
         var has = (await users.GetUserByIdAsync(userId))?.GoogleId is not null;
         return has ? Ok() : Conflict();
     }
 
+    /// <summary>
+    /// Logs an existing user in with email and password credentials.
+    /// </summary>
+    /// <param name="request">Login request containing email and password.</param>
+    /// <param name="jwtService">Service used to generate an application JWT.</param>
+    /// <param name="repo">Repository used to check and authorize the user.</param>
+    /// <returns>An HTTP result containing a JWT when credentials are valid.</returns>
     [HttpPost("login")]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> LoginAsync([FromBody] LoginRequest request,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository repo)
@@ -379,7 +488,17 @@ public class AuthController : ControllerBase
         return Ok(jwtService.GenerateToken(email));
     }
 
+    /// <summary>
+    /// Creates a user account and sends or applies email verification based on the sign-up flow.
+    /// </summary>
+    /// <param name="request">Sign-up request containing user profile and credential details.</param>
+    /// <param name="emailService">Service used to send verification email messages.</param>
+    /// <param name="jwtService">Service used to generate an application JWT.</param>
+    /// <param name="repo">Repository used to create and verify the user.</param>
+    /// <returns>An HTTP result containing a JWT when the account is created.</returns>
     [HttpPost("sign-up")]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> SignUpAsync([FromBody] SignUpRequest request,
         [FromServices] EmailService emailService,
         [FromServices] JwtService jwtService,
@@ -412,7 +531,19 @@ public class AuthController : ControllerBase
         return Ok(newJwt);
     }
 
+    /// <summary>
+    /// Sends a new email verification message for the specified user.
+    /// </summary>
+    /// <param name="userId">Identifier of the user requesting another verification email.</param>
+    /// <param name="jwtService">Service used to validate the current JWT and generate a verification JWT.</param>
+    /// <param name="emailService">Service used to send the verification email message.</param>
+    /// <param name="usersRepo">Repository used to load and inspect the user.</param>
+    /// <returns>An HTTP result indicating whether the verification email was sent.</returns>
     [HttpGet("{userId:int}/resend-verify-email")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status208AlreadyReported)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> ResendVerifyEmailAsync([FromRoute] int userId,
         [FromServices] JwtService jwtService,
         [FromServices] EmailService emailService,
@@ -441,7 +572,17 @@ public class AuthController : ControllerBase
         return Ok();
     }
 
+    /// <summary>
+    /// Sends a password reset message to the user with the specified email address.
+    /// </summary>
+    /// <param name="email">Email address of the user requesting a password reset.</param>
+    /// <param name="usersRepo">Repository used to load the user.</param>
+    /// <param name="jwtService">Service used to generate a password reset JWT.</param>
+    /// <param name="emailService">Service used to send the password reset message.</param>
+    /// <returns>An HTTP result indicating whether a password reset message was sent.</returns>
     [HttpGet("{email}/reset-password")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> ResetPasswordAsync([FromRoute] string email,
         [FromServices] UsersRepository usersRepo,
         [FromServices] JwtService jwtService,

--- a/Devices/DevicesController.cs
+++ b/Devices/DevicesController.cs
@@ -14,6 +14,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 using Auth.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Repository;
@@ -23,11 +24,26 @@ using Shared.Models.Requests.Devices;
 
 namespace Devices;
 
+/// <summary>
+/// Handles device registration and FCM token management.
+/// </summary>
 [ApiController]
 [Route("/devices")]
 public class DevicesController : ControllerBase
 {
+    /// <summary>
+    /// Adds a device for a user, or moves an existing FCM token to the requested user.
+    /// </summary>
+    /// <param name="request">Device data to register.</param>
+    /// <param name="jwtService">JWT validation service.</param>
+    /// <param name="usersRepo">Repository used to verify the authenticated user exists.</param>
+    /// <param name="devicesRepo">Repository used to create or update the device record.</param>
+    /// <returns>An HTTP result indicating whether the device was added.</returns>
     [HttpPost("add")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> Add([FromBody] AddDeviceRequest request,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo,
@@ -53,7 +69,20 @@ public class DevicesController : ControllerBase
         return success ? Ok() : Conflict();
     }
 
+    /// <summary>
+    /// Updates an existing device FCM token.
+    /// </summary>
+    /// <param name="request">The old and new FCM token values.</param>
+    /// <param name="jwtService">JWT validation service.</param>
+    /// <param name="usersRepo">Repository used to verify the authenticated user exists.</param>
+    /// <param name="devicesRepo">Repository used to update the device record.</param>
+    /// <returns>An HTTP result indicating whether the device token was updated.</returns>
     [HttpPatch("update")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Update([FromBody] UpdateDeviceRequest request,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo,
@@ -79,7 +108,20 @@ public class DevicesController : ControllerBase
         return success ? Ok() : StatusCode(500, "Failed to update device");
     }
 
+    /// <summary>
+    /// Deletes a registered device by FCM token.
+    /// </summary>
+    /// <param name="fcmToken">FCM token identifying the device to delete.</param>
+    /// <param name="jwtService">JWT validation service.</param>
+    /// <param name="usersRepo">Repository used to verify the authenticated user exists.</param>
+    /// <param name="devicesRepo">Repository used to delete the device record.</param>
+    /// <returns>An HTTP result indicating whether the device was deleted.</returns>
     [HttpDelete("delete/{fcmToken}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Delete([FromRoute] string fcmToken,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo,

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+    <PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591</NoWarn>
+    </PropertyGroup>
+</Project>

--- a/Host/Host.csproj
+++ b/Host/Host.csproj
@@ -47,12 +47,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <EmbeddedResource Include="..\StrnadiAPI-openapi.yaml">
-        <Link>StrnadiAPI-openapi.yaml</Link>
-      </EmbeddedResource>
-    </ItemGroup>
-
-    <ItemGroup>
       <ProjectReference Include="..\Achievements\Achievements.csproj" />
       <ProjectReference Include="..\Articles\Articles.csproj" />
       <ProjectReference Include="..\Auth\Auth.csproj" />

--- a/Host/Program.cs
+++ b/Host/Program.cs
@@ -15,19 +15,19 @@
  */
 
 using System.Reflection;
-using System.Text;
 using Achievements;
 using Articles;
 using Auth;
 using Devices;
 using Dictionary;
 using Email;
-using Microsoft.OpenApi.Readers;
+using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Writers;
 using Photos;
 using Recordings;
 using Repository;
 using Shared.Extensions;
+using Swashbuckle.AspNetCore.Swagger;
 using Users;
 using Utils;
 
@@ -51,10 +51,50 @@ class Program
 
     static void ConfigureServices(WebApplicationBuilder builder, ConfigurationManager configuration)
     {
+        var defaultCorsPolicy = configuration["CORS:Default"]
+                                ?? throw new InvalidOperationException("CORS:Default configuration is required.");
+
         builder.Services.AddMemoryCache();
         builder.Services.AddLogging();
         builder.Services.AddHttpClient();
         builder.Services.AddEndpointsApiExplorer();
+        builder.Services.AddSwaggerGen(options =>
+        {
+            options.SwaggerDoc("v1", new OpenApiInfo
+            {
+                Title = "Strnadi API",
+                Version = "1.0.0",
+                Description =
+                    "HTTP API used by the Strnadi applications to manage user accounts, bird recordings, articles and other shared resources."
+            });
+            options.AddSecurityDefinition("bearerAuth", new OpenApiSecurityScheme
+            {
+                Type = SecuritySchemeType.Http,
+                Scheme = "bearer",
+                BearerFormat = "JWT",
+                In = ParameterLocation.Header,
+                Description = "JWT Authorization header using the Bearer scheme."
+            });
+            options.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "bearerAuth"
+                        }
+                    },
+                    []
+                }
+            });
+
+            foreach (string xmlDocumentationFilePath in GetXmlDocumentationFilePaths())
+            {
+                options.IncludeXmlComments(xmlDocumentationFilePath, includeControllerXmlComments: true);
+            }
+        });
         builder.Services.AddTools(configuration);
         builder.Services.AddControllers()
             .AddApplicationPart(typeof(UsersController).Assembly)
@@ -71,7 +111,7 @@ class Program
         builder.Services.AddAuthServices();
         builder.Services.AddCors(corsOptions =>
         {
-            corsOptions.AddPolicy(configuration["CORS:Default"], policyBuilder =>
+            corsOptions.AddPolicy(defaultCorsPolicy, policyBuilder =>
             {
                 policyBuilder
                     .AllowAnyOrigin()
@@ -83,14 +123,16 @@ class Program
 
     static void ConfigureApp(WebApplication app, IConfiguration configuration)
     {
-        var openApiDocument = LoadEmbeddedOpenApiDocument();
+        var defaultCorsPolicy = configuration["CORS:Default"]
+                                ?? throw new InvalidOperationException("CORS:Default configuration is required.");
 
-        app.UseCors(configuration["CORS:Default"]);
+        app.UseCors(defaultCorsPolicy);
         app.UseHttpsRedirection();
         app.UseRouting();
         app.MapControllers();
-        app.MapGet("/swagger/StrnadiAPI-openapi.yaml", () => Results.Text(openApiDocument.Yaml, "application/yaml"));
-        app.MapGet("/swagger/v1/swagger.json", () => Results.Text(openApiDocument.Json, "application/json"));
+        app.UseSwagger();
+        app.MapGet("/swagger/StrnadiAPI-openapi.yaml", (ISwaggerProvider swaggerProvider) =>
+            Results.Text(SerializeOpenApiAsYaml(swaggerProvider.GetSwagger("v1")), "application/yaml"));
         app.UseSwaggerUI(options =>
         {
             options.SwaggerEndpoint("/swagger/v1/swagger.json", "Strnadi API");
@@ -99,45 +141,34 @@ class Program
         });
     }
 
-    static OpenApiDocumentContent LoadEmbeddedOpenApiDocument()
+    static IEnumerable<string> GetXmlDocumentationFilePaths()
     {
-        const string resourceName = "Host.StrnadiAPI-openapi.yaml";
-        var assembly = Assembly.GetExecutingAssembly();
+        var basePath = AppContext.BaseDirectory;
+        string[] assemblyNames =
+        [
+            Assembly.GetExecutingAssembly().GetName().Name!,
+            "Achievements",
+            "Articles",
+            "Auth",
+            "Devices",
+            "Photos",
+            "Recordings",
+            "Repository",
+            "Shared",
+            "Users",
+            "Utils"
+        ];
 
-        using Stream? stream = assembly.GetManifestResourceStream(resourceName);
-        if (stream is null)
-        {
-            throw new InvalidOperationException($"Embedded OpenAPI document '{resourceName}' was not found.");
-        }
-
-        using var reader = new StreamReader(stream);
-        var yaml = reader.ReadToEnd();
-        var json = ConvertYamlToJson(yaml);
-
-        return new OpenApiDocumentContent(yaml, json);
+        return assemblyNames
+            .Select(assemblyName => Path.Combine(basePath, $"{assemblyName}.xml"))
+            .Where(File.Exists);
     }
 
-    static string ConvertYamlToJson(string yaml)
+    static string SerializeOpenApiAsYaml(Microsoft.OpenApi.Models.OpenApiDocument openApiDocument)
     {
-        var openApiDocument = new OpenApiStringReader().Read(yaml, out var diagnostic);
-        if (diagnostic.Errors.Count > 0)
-        {
-            var errorMessage = string.Join(Environment.NewLine, diagnostic.Errors.Select(error => error.Message));
-            throw new InvalidOperationException($"The embedded OpenAPI document contains errors:{Environment.NewLine}{errorMessage}");
-        }
-
-        using var stream = new MemoryStream();
-        using (var textWriter = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true))
-        {
-            var jsonWriter = new OpenApiJsonWriter(textWriter);
-            openApiDocument.SerializeAsV3(jsonWriter);
-            textWriter.Flush();
-        }
-
-        stream.Position = 0;
-        using var reader = new StreamReader(stream, Encoding.UTF8);
-        return reader.ReadToEnd();
+        using var writer = new StringWriter();
+        var yamlWriter = new OpenApiYamlWriter(writer);
+        openApiDocument.SerializeAsV3(yamlWriter);
+        return writer.ToString();
     }
-
-    private sealed record OpenApiDocumentContent(string Yaml, string Json);
 }

--- a/Photos/PhotosController.cs
+++ b/Photos/PhotosController.cs
@@ -14,6 +14,7 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 using Auth.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Repository;
 using Shared.Extensions;
@@ -22,12 +23,26 @@ using Shared.Models.Requests.Photos;
 
 namespace Photos;
 
+/// <summary>
+/// Handles photo upload endpoints.
+/// </summary>
 [ApiController]
 [Route("photos")]
 public class PhotosController : ControllerBase
 {
+    /// <summary>
+    /// Uploads and stores a photo for a recording.
+    /// </summary>
+    /// <param name="request">Recording photo data to upload.</param>
+    /// <param name="repo">Repository used to save the photo metadata and file.</param>
+    /// <param name="jwtService">JWT validation service.</param>
+    /// <returns>An HTTP result indicating whether the recording photo was saved.</returns>
     [HttpPost("upload/recording-photo")]
     [RequestSizeLimit(130023424)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> UploadRecPhoto([FromBody] UploadRecordingPhotoRequest request,
         [FromServices] PhotosRepository repo,
         [FromServices] JwtService jwtService)

--- a/Recordings/FilteredRecordingsController.cs
+++ b/Recordings/FilteredRecordingsController.cs
@@ -15,6 +15,7 @@
  */
 
 using Auth.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Repository;
 using Shared.Extensions;
@@ -25,11 +26,25 @@ using LogLevel = Shared.Logging.LogLevel;
 
 namespace Recordings;
 
+/// <summary>
+/// Provides endpoints for filtered recording parts and detected dialect records.
+/// </summary>
 [ApiController]
 [Route("/recordings/filtered")]
 public class FilteredRecordingsController : ControllerBase
 {
+    /// <summary>
+    /// Gets filtered recording parts, optionally limited by recording and verified states.
+    /// </summary>
+    /// <param name="recordingsRepo">Repository used to read filtered recording parts.</param>
+    /// <param name="recordingId">Optional recording identifier to filter by.</param>
+    /// <param name="verified">Whether to include only filtered parts in verified states.</param>
+    /// <returns>An HTTP response containing filtered parts, no content, or a conflict status.</returns>
     [HttpGet]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> GetFilteredPartsAsync([FromServices] RecordingsRepository recordingsRepo,
         [FromQuery] int? recordingId = null,
         [FromQuery] bool verified = false)
@@ -45,14 +60,34 @@ public class FilteredRecordingsController : ControllerBase
         return Ok(filtered);
     }
 
+    /// <summary>
+    /// Gets one filtered recording part by identifier.
+    /// </summary>
+    /// <param name="fpId">Filtered recording part identifier.</param>
+    /// <param name="recordingsRepo">Repository used to read the filtered recording part.</param>
+    /// <returns>An HTTP response containing the filtered part, or conflict when it is unavailable.</returns>
     [HttpGet("{fpId:int}")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> GetFilteredPartAsync([FromRoute] int fpId, [FromServices] RecordingsRepository recordingsRepo)
     {
         var fp = await recordingsRepo.GetFilteredPartAsync(fpId);
         return fp is not null ? Ok(fp) : Conflict();
     }
 
+    /// <summary>
+    /// Uploads a filtered recording part for an authenticated request.
+    /// </summary>
+    /// <param name="model">Filtered recording part data to upload.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="recordingsRepo">Repository used to create the filtered part.</param>
+    /// <returns>An HTTP response indicating upload success, authentication failure, or conflict.</returns>
     [HttpPost]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> UploadFilteredPartAsync(FilteredRecordingPartUploadRequest model,
         [FromServices] JwtService jwtService,
         [FromServices] RecordingsRepository recordingsRepo)
@@ -76,7 +111,20 @@ public class FilteredRecordingsController : ControllerBase
             Conflict();
     }
     
+    /// <summary>
+    /// Creates a manually confirmed filtered part and detected dialect for an administrator.
+    /// </summary>
+    /// <param name="req">Confirmed dialect and filtered part data.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="usersRepo">Repository used to authorize the current user as an administrator.</param>
+    /// <param name="recordingsRepo">Repository used to create filtered part and detected dialect records.</param>
+    /// <returns>An HTTP response indicating creation success or validation, authorization, conflict, or server error.</returns>
     [HttpPost("post-confirmed-dialect")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> PostConfirmedDialectAsync([FromBody] PostConfirmedDialectRequest req,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo,
@@ -118,7 +166,20 @@ public class FilteredRecordingsController : ControllerBase
         return Ok();
     }
 
+    /// <summary>
+    /// Updates confirmed dialect data and selected filtered part fields for an administrator.
+    /// </summary>
+    /// <param name="req">Confirmed dialect update request.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="usersRepo">Repository used to authorize the current user as an administrator.</param>
+    /// <param name="recordingsRepo">Repository used to update filtered part and detected dialect records.</param>
+    /// <returns>An HTTP response indicating update success or validation, authorization, conflict, or server error.</returns>
     [HttpPatch("update-confirmed-dialect")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> UpdateConfirmedDialectAsync([FromBody] UpdateConfirmedDialectRequest req,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo,
@@ -183,7 +244,21 @@ public class FilteredRecordingsController : ControllerBase
         return Ok();
     }
     
+    /// <summary>
+    /// Updates selected fields of a filtered recording part for an administrator.
+    /// </summary>
+    /// <param name="fpId">Filtered recording part identifier.</param>
+    /// <param name="req">Filtered part fields to update.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="usersRepo">Repository used to authorize the current user as an administrator.</param>
+    /// <param name="recordingsRepo">Repository used to update the filtered part.</param>
+    /// <returns>An HTTP response indicating update success or authentication, authorization, conflict, or server error.</returns>
     [HttpPatch("{fpId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> PatchFilteredPartAsync([FromRoute] int fpId,
         [FromBody] FilteredRecordingPartUpdateRequest req,
         [FromServices] JwtService jwtService,
@@ -222,8 +297,20 @@ public class FilteredRecordingsController : ControllerBase
         return updated ? Ok() : StatusCode(500);
     }
 
+    /// <summary>
+    /// Deletes a filtered recording part using the legacy confirmed dialect route.
+    /// </summary>
+    /// <param name="filteredPartId">Filtered recording part identifier.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="usersRepo">Repository used to authorize the current user as an administrator.</param>
+    /// <param name="recordingsRepo">Repository used to delete the filtered part.</param>
+    /// <returns>An HTTP response indicating deletion success or authentication, authorization, or conflict status.</returns>
     [Obsolete("Use /recordings/filtered/{fpId} DELETE instead")]
     [HttpDelete("delete-confirmed-dialect/{filteredPartId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> DeleteConfirmedDialectAsync([FromRoute] int filteredPartId,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo,
@@ -232,7 +319,19 @@ public class FilteredRecordingsController : ControllerBase
         return await DeleteFilteredPartAsync(filteredPartId, recordingsRepo, usersRepo, jwtService);
     }
 
+    /// <summary>
+    /// Deletes a filtered recording part for an administrator.
+    /// </summary>
+    /// <param name="fpId">Filtered recording part identifier.</param>
+    /// <param name="recordingsRepo">Repository used to delete the filtered part.</param>
+    /// <param name="usersRepo">Repository used to authorize the current user as an administrator.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <returns>An HTTP response indicating deletion success or authentication, authorization, or conflict status.</returns>
     [HttpDelete("{fpId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> DeleteFilteredPartAsync([FromRoute] int fpId, 
         [FromServices] RecordingsRepository recordingsRepo, 
         [FromServices] UsersRepository usersRepo, 
@@ -256,21 +355,50 @@ public class FilteredRecordingsController : ControllerBase
         return deleted ? Ok() : Conflict();
     }
 
+    /// <summary>
+    /// Gets all detected dialect records.
+    /// </summary>
+    /// <param name="repo">Repository used to read detected dialects.</param>
+    /// <returns>An HTTP response containing detected dialect records, or conflict when unavailable.</returns>
     [HttpGet("detected/")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> GetDetectedDialectsAsync([FromServices] RecordingsRepository repo)
     {
         var detected = await repo.GetDetectedDialectsAsync();
         return detected is not null ? Ok(detected) : Conflict();
     }
 
+    /// <summary>
+    /// Gets detected dialect records by detected dialect identifier.
+    /// </summary>
+    /// <param name="ddId">Detected dialect identifier.</param>
+    /// <param name="repo">Repository used to read detected dialects.</param>
+    /// <returns>An HTTP response containing matching detected dialect records, or conflict when unavailable.</returns>
     [HttpGet("detected/{ddId:int}")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> GetDetectedDialectAsync([FromRoute] int ddId, [FromServices] RecordingsRepository repo)
     {
         var detected = await repo.GetDetectedDialectsAsync(ddId);
         return detected is not null ? Ok(detected) : Conflict();
     }
 
+    /// <summary>
+    /// Creates a detected dialect record for an administrator.
+    /// </summary>
+    /// <param name="req">Detected dialect data to create.</param>
+    /// <param name="usersRepo">Repository used to authorize the current user as an administrator.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="repo">Repository used to create the detected dialect.</param>
+    /// <returns>An HTTP response indicating creation success or authentication, authorization, or conflict status.</returns>
     [HttpPost("detected/")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> PostDetectedDialectAsync([FromBody] DetectedDialectUploadRequest req,
         [FromServices] UsersRepository usersRepo,
         [FromServices] JwtService jwtService,
@@ -291,7 +419,19 @@ public class FilteredRecordingsController : ControllerBase
         return created ? Created() : Conflict();
     }
 
+    /// <summary>
+    /// Updates selected fields of a detected dialect record for an administrator.
+    /// </summary>
+    /// <param name="req">Detected dialect fields to update.</param>
+    /// <param name="usersRepo">Repository used to authorize the current user as an administrator.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="repo">Repository used to update the detected dialect.</param>
+    /// <returns>An HTTP response indicating update success or authentication, authorization, or conflict status.</returns>
     [HttpPatch("detected/")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> PatchDetectedDialectsAsync([FromBody] UpdateDetectedDialectRequest req,
         [FromServices] UsersRepository usersRepo,
         [FromServices] JwtService jwtService,
@@ -312,7 +452,19 @@ public class FilteredRecordingsController : ControllerBase
         return updated ? Ok() : Conflict();
     }
 
+    /// <summary>
+    /// Deletes a detected dialect record for an administrator.
+    /// </summary>
+    /// <param name="ddId">Detected dialect identifier.</param>
+    /// <param name="usersRepo">Repository used to authorize the current user as an administrator.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="repo">Repository used to delete the detected dialect.</param>
+    /// <returns>An HTTP response indicating deletion success or authentication, authorization, or conflict status.</returns>
     [HttpDelete("detected/{ddId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> DeleteDetectedDialectsAsync([FromRoute] int ddId,
         [FromServices] UsersRepository usersRepo,
         [FromServices] JwtService jwtService,

--- a/Recordings/RecordingsController.cs
+++ b/Recordings/RecordingsController.cs
@@ -32,6 +32,9 @@ using LogLevel = Shared.Logging.LogLevel;
 
 namespace Recordings;
 
+/// <summary>
+/// Provides endpoints for recording metadata, recording parts, audio files, and dialect lookup data.
+/// </summary>
 [ApiController]
 [Route("recordings")]
 public class RecordingsController : ControllerBase
@@ -45,7 +48,19 @@ public class RecordingsController : ControllerBase
         _logger = logger;
     }
 
+    /// <summary>
+    /// Gets completed, non-deleted recordings, optionally filtered by user and expanded with parts or sound data.
+    /// </summary>
+    /// <param name="repo">Repository used to read recordings.</param>
+    /// <param name="userId">Optional user identifier to filter recordings by owner.</param>
+    /// <param name="parts">Whether to include recording parts.</param>
+    /// <param name="sound">Whether to include part audio data when parts are requested.</param>
+    /// <returns>An HTTP response containing recordings, no content when none exist, or an error status.</returns>
     [HttpGet]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetRecordingsAsync([FromServices] RecordingsRepository repo,
         [FromQuery] int? userId = null,
         [FromQuery] bool parts = false,
@@ -62,7 +77,20 @@ public class RecordingsController : ControllerBase
         return Ok(recordings);
     }
 
+    /// <summary>
+    /// Gets recordings marked as deleted for an authenticated administrator.
+    /// </summary>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="usersRepo">Repository used to resolve and authorize the current user.</param>
+    /// <param name="recordingsRepo">Repository used to read deleted recordings.</param>
+    /// <returns>An HTTP response containing deleted recordings, no content, or an authentication or error status.</returns>
     [HttpGet("deleted")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetDeletedAsync([FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo,
         [FromServices] RecordingsRepository recordingsRepo)
@@ -93,7 +121,18 @@ public class RecordingsController : ControllerBase
         return Ok(recordings);
     }
 
+    /// <summary>
+    /// Gets one non-deleted recording by identifier, optionally expanded with parts or sound data.
+    /// </summary>
+    /// <param name="id">Recording identifier.</param>
+    /// <param name="repo">Repository used to read the recording.</param>
+    /// <param name="parts">Whether to include recording parts.</param>
+    /// <param name="sound">Whether to include part audio data when parts are requested.</param>
+    /// <returns>An HTTP response containing the recording, or no content when it does not exist or is deleted.</returns>
     [HttpGet("{id:int}")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
     public async Task<IActionResult> GetRecordingAsync(int id,
         [FromServices] RecordingsRepository repo,
         [FromQuery] bool parts = false,
@@ -107,8 +146,18 @@ public class RecordingsController : ControllerBase
         return Ok(recording);
     }
 
+    /// <summary>
+    /// Gets the WAV audio file for a recording part using the legacy route.
+    /// </summary>
+    /// <param name="recId">Recording identifier from the legacy route.</param>
+    /// <param name="partId">Recording part identifier.</param>
+    /// <param name="repo">Repository used to locate the recording part file.</param>
+    /// <returns>An HTTP response streaming the WAV file, or not found when the file is unavailable.</returns>
     [Obsolete("use part/{partId:int} GET instead")]
     [HttpGet("part/{recId:int}/{partId:int}/sound")]
+    [Produces("audio/wav")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetSound([FromRoute] int recId,
         [FromRoute] int partId,
         [FromServices] RecordingsRepository repo)
@@ -119,7 +168,16 @@ public class RecordingsController : ControllerBase
         return PhysicalFile(part.FilePath, "audio/wav", enableRangeProcessing: true);
     }
     
+    /// <summary>
+    /// Gets the WAV audio file for a recording part.
+    /// </summary>
+    /// <param name="partId">Recording part identifier.</param>
+    /// <param name="repo">Repository used to locate the recording part file.</param>
+    /// <returns>An HTTP response streaming the WAV file, or not found when the file is unavailable.</returns>
     [HttpGet("part/{partId:int}/sound")]
+    [Produces("audio/wav")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetSound([FromRoute] int partId, [FromServices] RecordingsRepository repo)
     {
         var part = await repo.GetPartAsync(partId);
@@ -129,7 +187,21 @@ public class RecordingsController : ControllerBase
         return PhysicalFile(part.FilePath, "audio/wav", enableRangeProcessing: true);
     }
 
+    /// <summary>
+    /// Deletes or permanently deletes a recording when the authenticated user is the owner or an administrator.
+    /// </summary>
+    /// <param name="id">Recording identifier.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="usersRepo">Repository used to resolve and authorize the current user.</param>
+    /// <param name="recordingsRepo">Repository used to check ownership and delete the recording.</param>
+    /// <param name="final">Whether to permanently delete instead of marking the recording as deleted.</param>
+    /// <returns>An HTTP response indicating deletion success, authorization failure, missing recording, or conflict.</returns>
     [HttpDelete("{id:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> DeleteRecordingAsync([FromRoute] int id,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo,
@@ -164,7 +236,20 @@ public class RecordingsController : ControllerBase
         return deleted ? Ok() : Conflict();
     }
 
+    /// <summary>
+    /// Creates a recording for the authenticated user and schedules a later completeness check when possible.
+    /// </summary>
+    /// <param name="request">Recording metadata to upload.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="recordingsRepo">Repository used to create the recording.</param>
+    /// <param name="usersRepo">Repository used to resolve the current user.</param>
+    /// <returns>An HTTP response containing the new recording identifier, or an authentication or conflict status.</returns>
     [HttpPost]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> UploadAsync([FromBody] RecordingUploadRequest request,
         [FromServices] JwtService jwtService,
         [FromServices] RecordingsRepository recordingsRepo,
@@ -219,8 +304,20 @@ public class RecordingsController : ControllerBase
         Logger.Log("Scheduled", LogLevel.Debug);
     }
 
+    /// <summary>
+    /// Uploads a recording part with Base64-encoded audio for an authenticated request.
+    /// </summary>
+    /// <param name="request">Recording part metadata and Base64 audio data.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="recordingsRepo">Repository used to create the part and store its audio.</param>
+    /// <returns>An HTTP response containing the new part identifier, or an authentication or error status.</returns>
     [HttpPost("part")]
     [RequestSizeLimit(int.MaxValue)]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> UploadPartAsync([FromBody] RecordingPartUploadRequest request,
         [FromServices] JwtService jwtService,
         [FromServices] RecordingsRepository recordingsRepo)
@@ -244,8 +341,23 @@ public class RecordingsController : ControllerBase
             : StatusCode(500, "Failed to upload recording");
     }
 
+    /// <summary>
+    /// Uploads a recording part with multipart audio data and queues automatic audio classification.
+    /// </summary>
+    /// <param name="request">Recording part metadata from the submitted form.</param>
+    /// <param name="file">Uploaded audio file for the recording part.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="recordingsRepo">Repository used to create the part and store its audio.</param>
+    /// <param name="modelConnector">AI model connector used by the queued classification task.</param>
+    /// <param name="audioProcessingQueue">Queue used to run audio classification in the background.</param>
+    /// <returns>An HTTP response containing the new part identifier, or an authentication or error status.</returns>
     [HttpPost("part-new")]
     [RequestSizeLimit(int.MaxValue)]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> UploadPartAsync([FromForm] RecordingPartUploadRequest request,
         IFormFile file,
         [FromServices] JwtService jwtService,
@@ -306,7 +418,20 @@ public class RecordingsController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Gets identifiers of recordings owned by the authenticated user that have fewer parts than expected.
+    /// </summary>
+    /// <param name="recordingsRepo">Repository used to read incomplete recordings.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="usersRepo">Repository used to resolve the current user.</param>
+    /// <returns>An HTTP response containing incomplete recording identifiers, no content, or an authentication or error status.</returns>
     [HttpGet("incomplete")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetIncompleteRecordingsAsync([FromServices] RecordingsRepository recordingsRepo, 
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo)
@@ -334,7 +459,21 @@ public class RecordingsController : ControllerBase
         return Ok(recordings);
     }
 
+    /// <summary>
+    /// Updates recording metadata when the authenticated user is authorized for the recording.
+    /// </summary>
+    /// <param name="id">Recording identifier.</param>
+    /// <param name="request">Recording fields to update.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="usersRepo">Repository used to resolve the current user and recording owner.</param>
+    /// <param name="recordingsRepo">Repository used to read and update the recording.</param>
+    /// <returns>An HTTP response indicating update success, authorization failure, missing recording, or conflict.</returns>
     [HttpPatch("{id:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> EditAsync([FromRoute] int id,
         [FromBody] UpdateRecordingRequest request,
         [FromServices] JwtService jwtService,
@@ -368,7 +507,14 @@ public class RecordingsController : ControllerBase
         return updated ? Ok() : Conflict();
     }
 
+    /// <summary>
+    /// Gets all configured dialects.
+    /// </summary>
+    /// <param name="recordingsRepo">Repository used to read dialect records.</param>
+    /// <returns>An HTTP response containing dialect records.</returns>
     [HttpGet("dialects")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<IActionResult> GetDialects([FromServices] RecordingsRepository recordingsRepo)
     {
         return Ok(await recordingsRepo.GetDialectsAsync());

--- a/Repository/AchievementsRepository.cs
+++ b/Repository/AchievementsRepository.cs
@@ -7,10 +7,17 @@ using Shared.Tools;
 
 namespace Repository;
 
+/// <summary>
+/// Provides database and file operations for achievements.
+/// </summary>
 public class AchievementsRepository : RepositoryBase
 {
     private LinkGenerator _linkGenerator;
     
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AchievementsRepository"/> class.
+    /// </summary>
+    /// <param name="configuration">Application configuration used by the repository base.</param>
     public AchievementsRepository(IConfiguration configuration) : base(configuration)
     {
         _linkGenerator = new LinkGenerator(configuration);
@@ -21,6 +28,10 @@ public class AchievementsRepository : RepositoryBase
             "SELECT * FROM achievement_content WHERE achievement_id = @Id",
             new { Id = achievementId })))?.ToArray();
     
+    /// <summary>
+    /// Gets all achievements with generated image URLs and localized contents.
+    /// </summary>
+    /// <returns>All achievements, or <c>null</c> when the query fails.</returns>
     public async Task<Achievement[]?> GetAllAsync()
     {
         var achievements = await ExecuteSafelyAsync(Connection.QueryAsync<Achievement>(
@@ -39,6 +50,11 @@ public class AchievementsRepository : RepositoryBase
         return arr;
     }
 
+    /// <summary>
+    /// Gets achievements awarded to a specific user.
+    /// </summary>
+    /// <param name="userId">User identifier to query.</param>
+    /// <returns>The user's awarded achievements, or <c>null</c> when the query fails.</returns>
     public async Task<Achievement[]?> GetByUserIdAsync(int userId)
     {
         var achievements = await ExecuteSafelyAsync(Connection.QueryAsync<Achievement>(
@@ -65,10 +81,20 @@ public class AchievementsRepository : RepositoryBase
         return arr;
     }
 
+    /// <summary>
+    /// Gets an achievement by identifier.
+    /// </summary>
+    /// <param name="achievementId">Achievement identifier to query.</param>
+    /// <returns>The matching achievement, or <c>null</c> when no achievement is found.</returns>
     public async Task<Achievement?> GetByIdAsync(int achievementId) =>
         await ExecuteSafelyAsync(Connection.QueryFirstOrDefaultAsync<Achievement>(
             "SELECT * FROM achievements WHERE id = @Id", new { Id = achievementId }));
 
+    /// <summary>
+    /// Reads the stored image bytes for an achievement.
+    /// </summary>
+    /// <param name="achievementId">Achievement identifier associated with the image.</param>
+    /// <returns>The image bytes, or <c>null</c> when the achievement is not found.</returns>
     public async Task<byte[]?> GetPhotoAsync(int achievementId)
     {
         var achievement = await GetByIdAsync(achievementId);
@@ -110,6 +136,12 @@ public class AchievementsRepository : RepositoryBase
             await transaction.CommitAsync();
         });
 
+    /// <summary>
+    /// Creates an achievement, saves its image, and inserts localized content.
+    /// </summary>
+    /// <param name="req">Achievement data to insert.</param>
+    /// <param name="file">Image file to store for the achievement.</param>
+    /// <returns><c>true</c> when the achievement is created; otherwise, <c>false</c>.</returns>
     public async Task<bool> CreateAchievementAsync(PostAchievementRequest req, IFormFile file)
     {
         var insertedId = await InsertAchievementAsync(req.Sql);
@@ -125,6 +157,10 @@ public class AchievementsRepository : RepositoryBase
         return true;
     }
 
+    /// <summary>
+    /// Evaluates achievement SQL queries and awards matching achievements to users.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous award operation.</returns>
     public async Task CheckAndAwardAchievements()
     {
         var achievements = await GetAllAsync();

--- a/Repository/ArticlesRepository.cs
+++ b/Repository/ArticlesRepository.cs
@@ -8,12 +8,23 @@ using Shared.Tools;
 
 namespace Repository;
 
+/// <summary>
+/// Provides data and file persistence operations for articles, article attachments, and article categories.
+/// </summary>
 public class ArticlesRepository : RepositoryBase
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArticlesRepository"/> class.
+    /// </summary>
+    /// <param name="configuration">Application configuration used to initialize the repository connection.</param>
     public ArticlesRepository(IConfiguration configuration) : base(configuration)
     {
     }
 
+    /// <summary>
+    /// Gets all articles with their attachments and categories.
+    /// </summary>
+    /// <returns>An array of articles, or null when the query fails.</returns>
     public async Task<Article[]?> GetAsync()
     {
         var articles = await GetArticlesAsync();
@@ -64,6 +75,11 @@ public class ArticlesRepository : RepositoryBase
                     ArticleId = articleId
                 })).ToArray());
 
+    /// <summary>
+    /// Gets articles assigned to a category by category name.
+    /// </summary>
+    /// <param name="categoryName">The category name to query.</param>
+    /// <returns>An array of articles assigned to the category, or null when the query fails.</returns>
     public async Task<Article[]?> GetAsync(string categoryName)
     {
         var assignments = await GetCategoryAssignmentsByCategoryAsync(categoryName);
@@ -93,6 +109,11 @@ public class ArticlesRepository : RepositoryBase
                 )
                 """, new { CategoryName = categoryName })).ToArray());
 
+    /// <summary>
+    /// Gets an article by id with its attachments and categories.
+    /// </summary>
+    /// <param name="id">The article id.</param>
+    /// <returns>The article, or null when it does not exist or the query fails.</returns>
     public async Task<Article?> GetAsync(int id)
     {
         var article = await GetArticleAsync(id);
@@ -153,6 +174,12 @@ public class ArticlesRepository : RepositoryBase
                 "SELECT * FROM article_categories WHERE id = @CategoryId", 
                 new { CategoryId = categoryId }));
 
+    /// <summary>
+    /// Gets an article attachment file by article id and file name.
+    /// </summary>
+    /// <param name="id">The article id.</param>
+    /// <param name="fileName">The attachment file name.</param>
+    /// <returns>The attachment bytes, or null when the file does not exist.</returns>
     public async Task<byte[]?> GetAsync(int id, string fileName)
     {
         if (!FileSystemHelper.ArticleFileExists(id, fileName))
@@ -162,6 +189,11 @@ public class ArticlesRepository : RepositoryBase
         return content;
     }
 
+    /// <summary>
+    /// Saves a new article.
+    /// </summary>
+    /// <param name="req">The article data to save.</param>
+    /// <returns>The created article id, or null when the insert fails.</returns>
     public async Task<int?> SaveArticleAsync(ArticleUploadRequest req) =>
         await ExecuteSafelyAsync(async () =>
             await Connection.ExecuteScalarAsync<int?>(
@@ -171,6 +203,13 @@ public class ArticlesRepository : RepositoryBase
                 RETURNING id
                 """, new { req.Name, req.Description }));
 
+    /// <summary>
+    /// Saves an article attachment file and records it in the database.
+    /// </summary>
+    /// <param name="articleId">The article id.</param>
+    /// <param name="fileName">The attachment file name.</param>
+    /// <param name="base64">The attachment content encoded as Base64.</param>
+    /// <returns>True when the database record is inserted; otherwise, false.</returns>
     public async Task<bool> SaveArticleAttachmentAsync(int articleId, string fileName, string base64)
     {
         await FileSystemHelper.SaveArticleFileAsync(articleId, fileName, base64);
@@ -189,6 +228,12 @@ public class ArticlesRepository : RepositoryBase
         await ExecuteSafelyAsync(async () =>
             await Connection.ExecuteScalarAsync<int>("SELECT COUNT(*) FROM articles WHERE id = @Id", new { Id = id }) != 0);
 
+    /// <summary>
+    /// Updates an existing article.
+    /// </summary>
+    /// <param name="id">The article id.</param>
+    /// <param name="req">The article fields to update.</param>
+    /// <returns>True when the article exists and is updated; otherwise, false.</returns>
     public async Task<bool> UpdateArticleAsync(int id, ArticleUpdateRequest req)
     {
         if (!await ExistsAsync(id))
@@ -217,6 +262,13 @@ public class ArticlesRepository : RepositoryBase
         });
     }
 
+    /// <summary>
+    /// Replaces an article attachment file.
+    /// </summary>
+    /// <param name="id">The article id.</param>
+    /// <param name="fileName">The attachment file name.</param>
+    /// <param name="base64">The replacement attachment content encoded as Base64.</param>
+    /// <returns>True when the article exists and the file is saved; otherwise, false.</returns>
     public async Task<bool> UpdateArticleAttachmentAsync(int id, string fileName, string base64)
     {
         if (!await ExistsAsync(id))
@@ -226,6 +278,11 @@ public class ArticlesRepository : RepositoryBase
         return true;
     }
 
+    /// <summary>
+    /// Deletes an article by id.
+    /// </summary>
+    /// <param name="id">The article id.</param>
+    /// <returns>True when the article exists and is deleted; otherwise, false.</returns>
     public async Task<bool> DeleteArticleAsync(int id)
     {
         if (!await ExistsAsync(id))
@@ -235,6 +292,12 @@ public class ArticlesRepository : RepositoryBase
             await Connection.ExecuteAsync("DELETE FROM articles WHERE id = @Id", new { Id = id }) != 0);
     }
 
+    /// <summary>
+    /// Deletes an article attachment file and its database record.
+    /// </summary>
+    /// <param name="id">The article id.</param>
+    /// <param name="fileName">The attachment file name.</param>
+    /// <returns>True when the article exists and the database record is deleted; otherwise, false.</returns>
     public async Task<bool> DeleteArticleAttachmentAsync(int id, string fileName)
     {
         if (!await ExistsAsync(id))
@@ -253,11 +316,19 @@ public class ArticlesRepository : RepositoryBase
             0); 
     }
 
+    /// <summary>
+    /// Gets all article categories.
+    /// </summary>
+    /// <returns>An array of article categories, or null when the query fails.</returns>
     public async Task<ArticleCategory[]?> GetCategoriesAsync() =>
         await ExecuteSafelyAsync(async () => 
             (await Connection.QueryAsync<ArticleCategory>(
                 "SELECT * FROM article_categories")).ToArray());
     
+    /// <summary>
+    /// Gets all article categories with articles assigned to each category.
+    /// </summary>
+    /// <returns>An array of article categories with articles, or null when a query fails.</returns>
     public async Task<ArticleCategory[]?> GetCategoriesWithArticlesAsync()
     {
         var categories = await GetCategoriesAsync();
@@ -275,6 +346,11 @@ public class ArticlesRepository : RepositoryBase
         return categories;
     }
 
+    /// <summary>
+    /// Saves a new article category.
+    /// </summary>
+    /// <param name="req">The category data to save.</param>
+    /// <returns>True when the category is inserted; otherwise, false.</returns>
     public async Task<bool> SaveArticleCategoryAsync(ArticleCategoryUploadRequest req) =>
         await ExecuteSafelyAsync(async () =>
             await Connection.ExecuteAsync(
@@ -288,6 +364,12 @@ public class ArticlesRepository : RepositoryBase
             await Connection.QueryFirstOrDefaultAsync<ArticleCategory>(
                 "SELECT * FROM article_categories WHERE name = @Name", new { Name = categoryName }));
     
+    /// <summary>
+    /// Assigns an article to an article category.
+    /// </summary>
+    /// <param name="categoryName">The category name.</param>
+    /// <param name="request">The article assignment data.</param>
+    /// <returns>True when the category exists and the assignment is inserted; otherwise, false.</returns>
     public async Task<bool> AssignArticleToCategoryAsync(string categoryName, AssignArticleToCategoryRequest request)
     {
         var category = await GetCategoryModelAsync(categoryName);
@@ -311,10 +393,21 @@ public class ArticlesRepository : RepositoryBase
                     Order = order
                 })) != 0;
 
+    /// <summary>
+    /// Deletes an article category by category name.
+    /// </summary>
+    /// <param name="categoryName">The category name.</param>
+    /// <returns>True when the category is deleted; otherwise, false.</returns>
     public async Task<bool> DeleteCategoryAsync(string categoryName) =>
         await Connection.ExecuteAsync(
             "DELETE FROM article_categories WHERE name = @CategoryName", new { CategoryName = categoryName }) != 0;
 
+    /// <summary>
+    /// Removes an article from an article category.
+    /// </summary>
+    /// <param name="categoryName">The category name.</param>
+    /// <param name="articleId">The article id.</param>
+    /// <returns>True when the category exists and the assignment is deleted; otherwise, false.</returns>
     public async Task<bool> DeleteArticleCategoryAssignmentAsync(string categoryName, int articleId)
     {
         var category = await GetCategoryModelAsync(categoryName);

--- a/Repository/DevicesRepository.cs
+++ b/Repository/DevicesRepository.cs
@@ -20,12 +20,24 @@ using Shared.Models.Requests.Devices;
 
 namespace Repository;
 
+/// <summary>
+/// Provides database operations for registered devices and FCM tokens.
+/// </summary>
 public class DevicesRepository : RepositoryBase
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DevicesRepository"/> class.
+    /// </summary>
+    /// <param name="configuration">Application configuration used by the repository base.</param>
     public DevicesRepository(IConfiguration configuration) : base(configuration)
     {
     }
 
+    /// <summary>
+    /// Checks whether a device exists for the specified FCM token.
+    /// </summary>
+    /// <param name="fcmToken">FCM token to look up.</param>
+    /// <returns><c>true</c> when a matching device exists; otherwise, <c>false</c>.</returns>
     public async Task<bool> ExistsAsync(string fcmToken) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -33,6 +45,11 @@ public class DevicesRepository : RepositoryBase
             return await Connection.ExecuteScalarAsync<int>(sql, new { FcmToken = fcmToken }) != 0;
         });
     
+    /// <summary>
+    /// Inserts a new device record.
+    /// </summary>
+    /// <param name="request">Device data to insert.</param>
+    /// <returns><c>true</c> when the insert affects a row; otherwise, <c>false</c>.</returns>
     public async Task<bool> AddAsync(AddDeviceRequest request) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -50,6 +67,11 @@ public class DevicesRepository : RepositoryBase
             }) != 0;
         });
 
+    /// <summary>
+    /// Replaces an existing device FCM token.
+    /// </summary>
+    /// <param name="request">The old and new token values.</param>
+    /// <returns><c>true</c> when the token is updated; otherwise, <c>false</c>.</returns>
     public async Task<bool> UpdateAsync(UpdateDeviceRequest request) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -65,6 +87,11 @@ public class DevicesRepository : RepositoryBase
             }) != 0;
         });
 
+    /// <summary>
+    /// Deletes a device by FCM token.
+    /// </summary>
+    /// <param name="fcmToken">FCM token identifying the device to delete.</param>
+    /// <returns><c>true</c> when the device is deleted; otherwise, <c>false</c>.</returns>
     public async Task<bool> DeleteAsync(string fcmToken) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -76,6 +103,12 @@ public class DevicesRepository : RepositoryBase
             return await Connection.ExecuteAsync(sql, new { FcmToken = fcmToken }) != 0;
         });
 
+    /// <summary>
+    /// Assigns an existing device token to another user.
+    /// </summary>
+    /// <param name="newUserId">Identifier of the user who should own the device.</param>
+    /// <param name="oldFcmToken">Existing FCM token to update.</param>
+    /// <returns><c>true</c> when the owner is updated; otherwise, <c>false</c>.</returns>
     public async Task<bool> ChangeUserAsync(int newUserId, string oldFcmToken) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -92,6 +125,11 @@ public class DevicesRepository : RepositoryBase
                        }) != 0;
         });
 
+    /// <summary>
+    /// Gets all devices registered to a user.
+    /// </summary>
+    /// <param name="userId">User identifier to query.</param>
+    /// <returns>The user's devices, or <c>null</c> when the query fails.</returns>
     public async Task<IEnumerable<Device>?> GetAllByUserIdAsync(int userId) =>
         await ExecuteSafelyAsync(Connection.QueryAsync<Device>(
             "SELECT * FROM devices WHERE user_id = @UserId",

--- a/Repository/PhotosRepository.cs
+++ b/Repository/PhotosRepository.cs
@@ -21,12 +21,24 @@ using Shared.Tools;
 
 namespace Repository;
 
+/// <summary>
+/// Provides database and file operations for stored photos.
+/// </summary>
 public class PhotosRepository : RepositoryBase
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PhotosRepository"/> class.
+    /// </summary>
+    /// <param name="configuration">Application configuration used by the repository base.</param>
     public PhotosRepository(IConfiguration configuration) : base(configuration)
     {
     }
 
+    /// <summary>
+    /// Stores a recording photo and updates its file path in the database.
+    /// </summary>
+    /// <param name="request">Recording photo upload data.</param>
+    /// <returns><c>true</c> when the photo record and file path are saved; otherwise, <c>false</c>.</returns>
     public async Task<bool> UploadRecPhotoAsync(UploadRecordingPhotoRequest request) => await ExecuteSafelyAsync(
         async () =>
         {
@@ -37,6 +49,12 @@ public class PhotosRepository : RepositoryBase
             return await UpdateRecPhotoFilePathAsync(id, path);
         });
 
+    /// <summary>
+    /// Stores a user's profile photo and updates its file path in the database.
+    /// </summary>
+    /// <param name="userId">User identifier associated with the photo.</param>
+    /// <param name="req">Profile photo data to store.</param>
+    /// <returns><c>true</c> when the photo record and file path are saved; otherwise, <c>false</c>.</returns>
     public async Task<bool> UploadUserPhotoAsync(int userId, UserProfilePhotoModel req)
         => await ExecuteSafelyAsync(async () =>
         {
@@ -87,6 +105,11 @@ public class PhotosRepository : RepositoryBase
         return await FileSystemHelper.SaveUserPhotoFileAsync(userId, base64, format);
     }
 
+    /// <summary>
+    /// Gets a user's profile photo as a base64 payload.
+    /// </summary>
+    /// <param name="userId">User identifier associated with the photo.</param>
+    /// <returns>The user's profile photo model, or <c>null</c> when no photo or file is found.</returns>
     public async Task<UserProfilePhotoModel?> GetUserPhotoAsync(int userId) =>
         await ExecuteSafelyAsync(async () =>
         {   

--- a/Repository/RecordingsRepository.cs
+++ b/Repository/RecordingsRepository.cs
@@ -30,16 +30,31 @@ using LogLevel = Shared.Logging.LogLevel;
 
 namespace Repository;
 
+/// <summary>
+/// Provides database and file-system operations for recordings, recording parts, filtered parts, and detected dialects.
+/// </summary>
 public class RecordingsRepository : RepositoryBase
 {
     private readonly TimeSpan _timeMatchTolerance = TimeSpan.FromSeconds(1);
     private readonly ILogger<RecordingsRepository> _logger;
     
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RecordingsRepository"/> class.
+    /// </summary>
+    /// <param name="logger">Logger used for repository diagnostics.</param>
+    /// <param name="configuration">Configuration used by the repository base to create database connections.</param>
     public RecordingsRepository(ILogger<RecordingsRepository> logger, IConfiguration configuration) : base(configuration)
     {
         _logger = logger;
     }
 
+    /// <summary>
+    /// Gets completed recordings, optionally filtered by owner and expanded with parts or sound data.
+    /// </summary>
+    /// <param name="userId">Optional owner user identifier.</param>
+    /// <param name="parts">Whether to include recording parts.</param>
+    /// <param name="sound">Whether to include Base64 audio data for included parts.</param>
+    /// <returns>An array of recordings, or <c>null</c> when retrieval fails.</returns>
     public async Task<Recording[]?> GetAsync(int? userId, bool parts, bool sound)
     {
         Recording[]? recordings = (userId is not null
@@ -86,6 +101,10 @@ public class RecordingsRepository : RepositoryBase
                 HAVING r.expected_parts_count = COUNT(rp.id);
                 """));
 
+    /// <summary>
+    /// Gets completed recordings that are marked as deleted.
+    /// </summary>
+    /// <returns>Deleted recordings, or <c>null</c> when retrieval fails.</returns>
     public async Task<IEnumerable<Recording>?> GetDeletedAsync() =>
         await ExecuteSafelyAsync(
             Connection.QueryAsync<Recording>(
@@ -100,6 +119,10 @@ public class RecordingsRepository : RepositoryBase
                 HAVING r.expected_parts_count = COUNT(rp.id);
                 """));
 
+    /// <summary>
+    /// Gets recordings that have not yet produced filtered parts in classification states.
+    /// </summary>
+    /// <returns>An array of recordings with parts attached, or <c>null</c> when retrieval fails.</returns>
     public async Task<Recording[]?> GetPreparedForClassificationAsync()
     {
         var recordings = await ExecuteSafelyAsync(
@@ -130,6 +153,13 @@ public class RecordingsRepository : RepositoryBase
         return recordings.ToArray();
     }
 
+    /// <summary>
+    /// Gets a recording by identifier, optionally expanded with parts or sound data.
+    /// </summary>
+    /// <param name="id">Recording identifier.</param>
+    /// <param name="parts">Whether to include recording parts.</param>
+    /// <param name="sound">Whether to include Base64 audio data for included parts.</param>
+    /// <returns>The recording when found, otherwise <c>null</c>.</returns>
     public async Task<Recording?> GetByIdAsync(int id, bool parts, bool sound)
     {
         var recording = await GetAsync(id);
@@ -162,6 +192,12 @@ public class RecordingsRepository : RepositoryBase
             return r;
         });
 
+    /// <summary>
+    /// Gets parts for a recording, optionally including Base64 audio data.
+    /// </summary>
+    /// <param name="recordingId">Recording identifier.</param>
+    /// <param name="sound">Whether to include Base64 audio data from each part file.</param>
+    /// <returns>Recording parts, or <c>null</c> when retrieval fails.</returns>
     public async Task<IEnumerable<RecordingPart>?> GetPartsAsync(int recordingId, bool sound) =>
         await ExecuteSafelyAsync<IEnumerable<RecordingPart>?>(async () =>
         {
@@ -200,6 +236,12 @@ public class RecordingsRepository : RepositoryBase
             return await Connection.QueryAsync<RecordingPart>(sql, new { RecordingId = recordingId });
         });
 
+    /// <summary>
+    /// Creates a recording metadata row for a user.
+    /// </summary>
+    /// <param name="userId">Owner user identifier.</param>
+    /// <param name="request">Recording metadata to insert.</param>
+    /// <returns>The new recording identifier, or <c>null</c> when insertion fails.</returns>
     public async Task<int?> UploadAsync(int userId, RecordingUploadRequest request) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -221,6 +263,11 @@ public class RecordingsRepository : RepositoryBase
             });
         });
     
+    /// <summary>
+    /// Creates a recording part and stores Base64-encoded audio on disk.
+    /// </summary>
+    /// <param name="request">Recording part metadata and Base64 audio data.</param>
+    /// <returns>The new recording part identifier, or <c>null</c> when creation fails.</returns>
     public async Task<int?> UploadPartAsync(RecordingPartUploadRequest request)
     {
         int? partId = await UploadPartModelToDbAsync(request);
@@ -234,6 +281,12 @@ public class RecordingsRepository : RepositoryBase
         return partId;
     }
 
+    /// <summary>
+    /// Creates a recording part and stores uploaded audio on disk.
+    /// </summary>
+    /// <param name="request">Recording part metadata.</param>
+    /// <param name="file">Uploaded audio file to store for the part.</param>
+    /// <returns>The new recording part identifier, or <c>null</c> when creation fails.</returns>
     public async Task<int?> UploadPartAsync(RecordingPartUploadRequest request, IFormFile file)
     {
         int? partId = await UploadPartModelToDbAsync(request);
@@ -293,6 +346,12 @@ public class RecordingsRepository : RepositoryBase
             )
         );
 
+    /// <summary>
+    /// Gets filtered recording parts, optionally limited by recording and verified states, with detected dialect codes populated.
+    /// </summary>
+    /// <param name="recordingId">Optional recording identifier to filter by.</param>
+    /// <param name="verified">Whether to include only filtered parts in verified states.</param>
+    /// <returns>An array of filtered recording parts, or <c>null</c> when retrieval fails.</returns>
     public async Task<FilteredRecordingPartModel[]?> GetFilteredPartsAsync(int? recordingId, bool verified)
     {
         var filteredParts = (await GetFilteredPartsRawAsync(recordingId, verified))?.ToArray();
@@ -333,11 +392,20 @@ public class RecordingsRepository : RepositoryBase
         await ExecuteSafelyAsync(async () =>
             (await Connection.QueryAsync<Dialect>("SELECT * FROM dialects")).ToArray());
     
+    /// <summary>
+    /// Gets all detected dialect records.
+    /// </summary>
+    /// <returns>An array of detected dialects, or <c>null</c> when retrieval fails.</returns>
     public async Task<DetectedDialect[]?> GetDetectedDialectsAsync() =>
         await ExecuteSafelyAsync(async () => (
                 await Connection.QueryAsync<DetectedDialect>("SELECT * FROM detected_dialects")).ToArray()
         );
     
+    /// <summary>
+    /// Gets detected dialect records by detected dialect identifier.
+    /// </summary>
+    /// <param name="ddId">Detected dialect identifier.</param>
+    /// <returns>An array of matching detected dialects, or <c>null</c> when retrieval fails.</returns>
     public async Task<DetectedDialect[]?> GetDetectedDialectsAsync(int ddId) =>
         await ExecuteSafelyAsync(async () => (
                 await Connection.QueryAsync<DetectedDialect>("SELECT * FROM detected_dialects WHERE id = @Id",
@@ -353,6 +421,11 @@ public class RecordingsRepository : RepositoryBase
                     FPartId = filteredPartId
                 })).ToArray());
 
+    /// <summary>
+    /// Creates a filtered recording part and records the user-guessed dialect.
+    /// </summary>
+    /// <param name="model">Filtered recording part upload data.</param>
+    /// <returns><c>true</c> when the filtered part and dialect record are inserted; otherwise <c>false</c>.</returns>
     public async Task<bool> UploadFilteredPartAsync(FilteredRecordingPartUploadRequest model)
     {
         int? dialectId = await GetDialectCodeIdAsync(model.DialectCode);
@@ -379,6 +452,11 @@ public class RecordingsRepository : RepositoryBase
                 State = (int)FilteredRecordingPartState.AwaitingProcession
             }));
 
+    /// <summary>
+    /// Gets the database identifier for a dialect code.
+    /// </summary>
+    /// <param name="dialectCode">Dialect code to look up.</param>
+    /// <returns>The dialect identifier, or <c>null</c> when no dialect matches or lookup fails.</returns>
     public async Task<int?> GetDialectCodeIdAsync(string dialectCode) =>
         await ExecuteSafelyAsync(Connection.ExecuteScalarAsync<int?>(sql:
                 "SELECT id FROM dialects WHERE dialect_code = @DialectCode", new
@@ -397,6 +475,14 @@ public class RecordingsRepository : RepositoryBase
                 UserGuessDialectId = userGuessDialectId
             })) != 0;
 
+    /// <summary>
+    /// Inserts a detected dialect record for a filtered recording part.
+    /// </summary>
+    /// <param name="filteredPartId">Filtered recording part identifier.</param>
+    /// <param name="userGuessDialectId">Optional user-guessed dialect identifier.</param>
+    /// <param name="confirmedDialectId">Optional confirmed dialect identifier.</param>
+    /// <param name="predictedDialectId">Optional predicted dialect identifier.</param>
+    /// <returns><c>true</c> when the record is inserted; otherwise <c>false</c>.</returns>
     public async Task<bool> InsertDetectedDialectAsync(int filteredPartId, int? userGuessDialectId,
         int? confirmedDialectId,
         int? predictedDialectId)
@@ -420,9 +506,20 @@ public class RecordingsRepository : RepositoryBase
             })) != 0;
     }
 
+    /// <summary>
+    /// Determines whether a recording exists.
+    /// </summary>
+    /// <param name="id">Recording identifier.</param>
+    /// <returns><c>true</c> when the recording exists; otherwise <c>false</c>.</returns>
     public async Task<bool> ExistsAsync(int id) =>
         await GetByIdAsync(id, false, false) is not null;
     
+    /// <summary>
+    /// Determines whether a user owns a recording.
+    /// </summary>
+    /// <param name="id">Recording identifier.</param>
+    /// <param name="userId">User identifier to compare with the recording owner.</param>
+    /// <returns><c>true</c> when the user owns the recording; otherwise <c>false</c>.</returns>
     public async Task<bool> IsOwnerAsync(int id, int userId)
     {
         if (!await ExistsAsync(id))
@@ -431,6 +528,12 @@ public class RecordingsRepository : RepositoryBase
         return (await GetByIdAsync(id, false, false))!.UserId == userId;
     }
 
+    /// <summary>
+    /// Deletes a recording permanently or marks it as deleted.
+    /// </summary>
+    /// <param name="id">Recording identifier.</param>
+    /// <param name="final">Whether to permanently delete the recording.</param>
+    /// <returns><c>true</c> when a row is affected; otherwise <c>false</c>.</returns>
     public async Task<bool> DeleteAsync(int id, bool final) =>
         await ExecuteSafelyAsync(Connection.ExecuteAsync(
             sql: final
@@ -438,6 +541,12 @@ public class RecordingsRepository : RepositoryBase
                 : "UPDATE recordings SET deleted = true WHERE id = @Id", 
             new { Id = id } ))!= 0;
 
+    /// <summary>
+    /// Updates recording metadata fields supplied by the request.
+    /// </summary>
+    /// <param name="recordingId">Recording identifier.</param>
+    /// <param name="request">Recording update request containing mapped database columns.</param>
+    /// <returns><c>true</c> when a row is updated; otherwise <c>false</c>.</returns>
     public async Task<bool> UpdateAsync(int recordingId, UpdateRecordingRequest request) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -457,11 +566,21 @@ public class RecordingsRepository : RepositoryBase
             return await Connection.ExecuteAsync(sql, parameters) != 0;
         });
 
+    /// <summary>
+    /// Gets a recording part by identifier.
+    /// </summary>
+    /// <param name="partId">Recording part identifier.</param>
+    /// <returns>The recording part when found, otherwise <c>null</c>.</returns>
     public async Task<RecordingPart?> GetPartAsync(int partId) =>
         await ExecuteSafelyAsync(Connection.QueryFirstOrDefaultAsync<RecordingPart>(
             "SELECT * FROM recording_parts WHERE id = @Id",
             new { Id = partId }));
     
+    /// <summary>
+    /// Reads the audio bytes for a recording part.
+    /// </summary>
+    /// <param name="partId">Recording part identifier.</param>
+    /// <returns>The audio bytes, or <c>null</c> when the part or file path is unavailable.</returns>
     public async Task<byte[]?> GetPartSoundAsync(int partId)
     {
         var part = await GetPartAsync(partId);
@@ -471,6 +590,13 @@ public class RecordingsRepository : RepositoryBase
         return await FileSystemHelper.ReadRecordingFileAsync(part.FilePath);
     }
 
+    /// <summary>
+    /// Finds a filtered part for a recording whose start and end times match within the repository tolerance.
+    /// </summary>
+    /// <param name="recordingId">Recording identifier.</param>
+    /// <param name="start">Start time to match.</param>
+    /// <param name="end">End time to match.</param>
+    /// <returns>The matching filtered part, or <c>null</c> when none is found or retrieval fails.</returns>
     public async Task<FilteredRecordingPartModel?> FindFilteredPartByTimeAsync(
         int recordingId, DateTime start, DateTime end) =>
         await ExecuteSafelyAsync(
@@ -491,6 +617,15 @@ public class RecordingsRepository : RepositoryBase
                     ToleranceSeconds = _timeMatchTolerance.Seconds
                 }));
 
+    /// <summary>
+    /// Creates a filtered recording part.
+    /// </summary>
+    /// <param name="recordingId">Recording identifier.</param>
+    /// <param name="startDate">Filtered part start time.</param>
+    /// <param name="endDate">Filtered part end time.</param>
+    /// <param name="state">Filtered part state.</param>
+    /// <param name="representant">Whether the filtered part is marked as representative.</param>
+    /// <returns>The created filtered part, or <c>null</c> when creation fails.</returns>
     public async Task<FilteredRecordingPartModel?> CreateFilteredPartAsync(
         int recordingId, DateTime startDate, DateTime endDate, FilteredRecordingPartState state, bool representant) =>
         await ExecuteSafelyAsync(
@@ -510,6 +645,17 @@ public class RecordingsRepository : RepositoryBase
                 }
             ));
 
+    /// <summary>
+    /// Updates selected fields of a filtered recording part.
+    /// </summary>
+    /// <param name="filteredPartId">Filtered recording part identifier.</param>
+    /// <param name="start">Optional start time to set.</param>
+    /// <param name="end">Optional end time to set.</param>
+    /// <param name="representant">Optional representative flag to set.</param>
+    /// <param name="state">Optional state to set.</param>
+    /// <param name="recordingId">Optional recording identifier to set.</param>
+    /// <param name="parentId">Optional parent filtered part identifier to set.</param>
+    /// <returns><c>true</c> when a row is updated; otherwise <c>false</c>.</returns>
     public async Task<bool> UpdateFilteredPartAsync(int filteredPartId, DateTime? start, DateTime? end,
         bool? representant, FilteredRecordingPartState? state, int? recordingId, int? parentId) =>
         await ExecuteSafelyAsync(async () =>
@@ -559,6 +705,14 @@ public class RecordingsRepository : RepositoryBase
             return await Connection.ExecuteAsync(sql, parameters) != 0;
         });
 
+    /// <summary>
+    /// Inserts or updates detected dialect codes for a filtered recording part.
+    /// </summary>
+    /// <param name="filteredPartId">Filtered recording part identifier.</param>
+    /// <param name="userGuessDialectCode">Optional user-guessed dialect code to set.</param>
+    /// <param name="confirmedDialectCode">Optional confirmed dialect code to set.</param>
+    /// <param name="predictedDialectCode">Optional predicted dialect code to set.</param>
+    /// <returns><c>true</c> when a detected dialect row is inserted or updated; otherwise <c>false</c>.</returns>
     public async Task<bool> UpsertDetectedDialectAsync(
         int filteredPartId,
         string? userGuessDialectCode = null,
@@ -616,6 +770,11 @@ public class RecordingsRepository : RepositoryBase
         return await ExecuteSafelyAsync(Connection.ExecuteAsync(sql, parameters)) != 0;    
     }
 
+    /// <summary>
+    /// Deletes a filtered recording part.
+    /// </summary>
+    /// <param name="filteredPartId">Filtered recording part identifier.</param>
+    /// <returns><c>true</c> when a row is deleted; otherwise <c>false</c>.</returns>
     public async Task<bool> DeleteFilteredPartAsync(int filteredPartId) =>
         await ExecuteSafelyAsync(
             Connection.ExecuteAsync(
@@ -625,6 +784,11 @@ public class RecordingsRepository : RepositoryBase
                     FilteredPartId = filteredPartId
                 })) != 0;
 
+    /// <summary>
+    /// Determines whether a filtered recording part exists.
+    /// </summary>
+    /// <param name="filteredPartId">Filtered recording part identifier.</param>
+    /// <returns><c>true</c> when the filtered part exists; otherwise <c>false</c>.</returns>
     public async Task<bool> ExistsFilteredPartAsync(int filteredPartId) =>
         await ExecuteSafelyAsync(
             Connection.ExecuteScalarAsync<int>(
@@ -635,6 +799,10 @@ public class RecordingsRepository : RepositoryBase
                 })
         ) != 0;
 
+    /// <summary>
+    /// Recalculates end times for recording parts whose start and end times are equal by inspecting audio duration.
+    /// </summary>
+    /// <returns>A task representing the asynchronous repair operation.</returns>
     public async Task FixSameDatesInPartsAsync()
     {
         var parts = await ExecuteSafelyAsync(
@@ -668,11 +836,19 @@ public class RecordingsRepository : RepositoryBase
         }
     }
 
+    /// <summary>
+    /// Gets all dialect records.
+    /// </summary>
+    /// <returns>An array of dialect records.</returns>
     public async Task<Dialect[]> GetDialectsAsync()
     {
         return (await Connection.QueryAsync<Dialect>("SELECT * FROM dialects")).ToArray();
     }
 
+    /// <summary>
+    /// Normalizes all stored recording part audio files that have a file path.
+    /// </summary>
+    /// <returns>A task representing the asynchronous normalization operation.</returns>
     public async Task NormalizeAudiosAsync()
     {
         var parts = await ExecuteSafelyAsync(
@@ -698,6 +874,10 @@ public class RecordingsRepository : RepositoryBase
         }
     }
 
+    /// <summary>
+    /// Logs detected file format and duration for stored recording part audio files that have a file path.
+    /// </summary>
+    /// <returns>A task representing the asynchronous analysis operation.</returns>
     public async Task AnalyzePartsAsync()
     {
         var parts = await ExecuteSafelyAsync(
@@ -719,6 +899,11 @@ public class RecordingsRepository : RepositoryBase
         }
     }
 
+    /// <summary>
+    /// Gets identifiers of recordings whose part count does not match the expected part count.
+    /// </summary>
+    /// <param name="userId">Owner user identifier.</param>
+    /// <returns>An array of incomplete recording identifiers, or <c>null</c> when retrieval fails.</returns>
     public async Task<int[]?> GetIncompleteRecordingsAsync(int userId)
     {
         var incomplete = await ExecuteSafelyAsync(Connection.QueryAsync<Recording>(
@@ -736,6 +921,12 @@ public class RecordingsRepository : RepositoryBase
         return incomplete?.Select(r => r.Id).ToArray();
     }
 
+    /// <summary>
+    /// Creates filtered parts and predicted dialect records from an AI prediction result for a recording part.
+    /// </summary>
+    /// <param name="recordingPartId">Recording part identifier.</param>
+    /// <param name="result">Prediction result containing segments and labels.</param>
+    /// <returns>A task representing the asynchronous prediction processing operation.</returns>
     public async Task ProcessPredictionAsync(int recordingPartId, PredicationResult result)
     {
         if (result is { Segments.Length: 0 })
@@ -780,10 +971,20 @@ public class RecordingsRepository : RepositoryBase
         }
     }
 
+    /// <summary>
+    /// Gets a filtered recording part by identifier.
+    /// </summary>
+    /// <param name="fpId">Filtered recording part identifier.</param>
+    /// <returns>The filtered recording part when found, otherwise <c>null</c>.</returns>
     public async Task<FilteredRecordingPartModel?> GetFilteredPartAsync(int fpId) =>
         await ExecuteSafelyAsync(Connection.QueryFirstOrDefaultAsync<FilteredRecordingPartModel>(
             "SELECT * FROM filtered_recording_parts WHERE id = @Id", new { Id = fpId }));
 
+    /// <summary>
+    /// Updates selected fields of a detected dialect record.
+    /// </summary>
+    /// <param name="req">Detected dialect update request.</param>
+    /// <returns><c>true</c> when a row is updated; otherwise <c>false</c>.</returns>
     public async Task<bool> UpdateDetectedDialectAsync(UpdateDetectedDialectRequest req) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -817,6 +1018,11 @@ public class RecordingsRepository : RepositoryBase
             return await Connection.ExecuteAsync(sql, parameters) != 0;
         });
 
+    /// <summary>
+    /// Deletes a detected dialect record.
+    /// </summary>
+    /// <param name="ddId">Detected dialect identifier.</param>
+    /// <returns><c>true</c> when the delete operation reports success; otherwise <c>false</c>.</returns>
     public async Task<bool> DeleteDetectedDialectAsync(int ddId) =>
         await ExecuteSafelyAsync(async () => await Connection.ExecuteScalarAsync<int>(
             "DELETE FROM detected_dialects WHERE id = @Id", new { Id = ddId }) == 0);

--- a/Repository/UsersRepository.cs
+++ b/Repository/UsersRepository.cs
@@ -28,12 +28,24 @@ using LogLevel = Shared.Logging.LogLevel;
 
 namespace Repository;
 
+/// <summary>
+/// Provides database access for user accounts, credentials, verification state, and external provider identifiers.
+/// </summary>
 public class UsersRepository : RepositoryBase
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UsersRepository"/> class.
+    /// </summary>
+    /// <param name="configuration">Application configuration used by the repository base.</param>
     public UsersRepository(IConfiguration configuration) : base(configuration)
     {
     }
     
+    /// <summary>
+    /// Checks whether a user exists with the specified email address.
+    /// </summary>
+    /// <param name="email">Email address to check.</param>
+    /// <returns><see langword="true"/> when a matching user exists; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> ExistsAsync(string email) =>
         await ExecuteSafelyAsync(async () => 
             await Connection.ExecuteScalarAsync<int>(
@@ -41,6 +53,11 @@ public class UsersRepository : RepositoryBase
                 new { Email = email }
                 )) != 0;
     
+    /// <summary>
+    /// Checks whether a user exists with the specified Apple identifier.
+    /// </summary>
+    /// <param name="appleId">Apple identifier to check.</param>
+    /// <returns><see langword="true"/> when a matching user exists; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> ExistsAppleAsync(string appleId) =>
         await ExecuteSafelyAsync(async () => 
             await Connection.ExecuteScalarAsync<int>(
@@ -48,6 +65,11 @@ public class UsersRepository : RepositoryBase
                 new { AppleId = appleId }
                 )) != 0;
 
+    /// <summary>
+    /// Checks whether a user exists with the specified user identifier.
+    /// </summary>
+    /// <param name="userId">User identifier to check.</param>
+    /// <returns><see langword="true"/> when a matching user exists; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> ExistsAsync(int userId) =>
         await ExecuteSafelyAsync(async () =>
             await Connection.ExecuteScalarAsync<int>(
@@ -55,6 +77,11 @@ public class UsersRepository : RepositoryBase
                 new { Id = userId }
             )) != 0;
     
+    /// <summary>
+    /// Checks whether a user exists with the specified Google identifier.
+    /// </summary>
+    /// <param name="googleId">Google identifier to check.</param>
+    /// <returns><see langword="true"/> when a matching user exists; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> ExistsGoogleAsync(string googleId) => 
         await ExecuteSafelyAsync(async () => 
             await Connection.ExecuteScalarAsync<int>(
@@ -63,6 +90,12 @@ public class UsersRepository : RepositoryBase
             )) != 0;
     
 
+    /// <summary>
+    /// Verifies email and password credentials for a user.
+    /// </summary>
+    /// <param name="email">Email address of the user to authorize.</param>
+    /// <param name="password">Plain-text password to verify against the stored hash.</param>
+    /// <returns><see langword="true"/> when the credentials are valid; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> AuthorizeAsync(string email, string password) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -88,6 +121,12 @@ public class UsersRepository : RepositoryBase
             return bcrypt.VerifyPassword(password, oldHashedPassword!);
         });
 
+    /// <summary>
+    /// Creates a new user from the supplied sign-up request.
+    /// </summary>
+    /// <param name="request">Sign-up request containing user profile and provider identifiers.</param>
+    /// <param name="regularRegister">Whether to hash and store the supplied password for a regular registration.</param>
+    /// <returns><see langword="true"/> when the user row is inserted; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> CreateUserAsync(SignUpRequest request, bool regularRegister) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -124,6 +163,11 @@ public class UsersRepository : RepositoryBase
             }) != 0;
         });
 
+    /// <summary>
+    /// Gets a user by database identifier.
+    /// </summary>
+    /// <param name="userId">User identifier to load.</param>
+    /// <returns>The matching user without the password value, or <see langword="null"/> when not found.</returns>
     public async Task<User?> GetUserByIdAsync(int userId) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -137,6 +181,11 @@ public class UsersRepository : RepositoryBase
             return user;
         });
     
+    /// <summary>
+    /// Gets a user by email address.
+    /// </summary>
+    /// <param name="email">Email address to load.</param>
+    /// <returns>The matching user without the password value, or <see langword="null"/> when not found.</returns>
     public async Task<User?> GetUserByEmailAsync(string email) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -150,6 +199,11 @@ public class UsersRepository : RepositoryBase
             return user;
         });
     
+    /// <summary>
+    /// Gets a user by Apple identifier.
+    /// </summary>
+    /// <param name="appleId">Apple identifier to load.</param>
+    /// <returns>The matching user without the password value, or <see langword="null"/> when not found.</returns>
     public async Task<User?> GetUserByAppleIdAsync(string appleId) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -163,16 +217,31 @@ public class UsersRepository : RepositoryBase
             return user;
         });
 
+    /// <summary>
+    /// Marks the user with the specified email address as email verified.
+    /// </summary>
+    /// <param name="email">Email address of the user to verify.</param>
+    /// <returns><see langword="true"/> when a user row is updated; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> VerifyEmailAsync(string email) =>
         await ExecuteSafelyAsync(async () =>
             await Connection.ExecuteAsync("UPDATE users SET is_email_verified = true WHERE email = @UserEmail",
                 new { UserEmail = email }) != 0);
 
+    /// <summary>
+    /// Marks the user with the specified identifier as email verified.
+    /// </summary>
+    /// <param name="userId">Identifier of the user to verify.</param>
+    /// <returns><see langword="true"/> when a user row is updated; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> VerifyEmailAsync(int userId) =>
         await ExecuteSafelyAsync(async () => 
             await Connection.ExecuteAsync("UPDATE users SET is_email_verified = true WHERE id = @UserId", 
                 new { UserId = userId }) != 0);
 
+    /// <summary>
+    /// Checks whether the user with the specified identifier has the administrator role.
+    /// </summary>
+    /// <param name="userId">Identifier of the user to inspect.</param>
+    /// <returns><see langword="true"/> when the user has the administrator role; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> IsAdminAsync(int userId) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -190,6 +259,11 @@ public class UsersRepository : RepositoryBase
             return await Connection.ExecuteScalarAsync<bool>(sql, new { UserId = userId });
         });
     
+    /// <summary>
+    /// Checks whether the user with the specified email address has the administrator role.
+    /// </summary>
+    /// <param name="email">Email address of the user to inspect.</param>
+    /// <returns><see langword="true"/> when the user has the administrator role; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> IsAdminAsync(string email) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -207,6 +281,12 @@ public class UsersRepository : RepositoryBase
             return await Connection.ExecuteScalarAsync<bool>(sql, new { Email = email });
         });
 
+    /// <summary>
+    /// Changes the stored password for the specified user.
+    /// </summary>
+    /// <param name="email">Email address of the user whose password should be changed.</param>
+    /// <param name="newPassword">New plain-text password to hash and store.</param>
+    /// <returns><see langword="true"/> when exactly one user row is updated; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> ChangePasswordAsync(string email, string newPassword) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -222,6 +302,11 @@ public class UsersRepository : RepositoryBase
                 }) == 1;
         });
 
+    /// <summary>
+    /// Checks whether the user with the specified email address has a verified email.
+    /// </summary>
+    /// <param name="email">Email address of the user to inspect.</param>
+    /// <returns><see langword="true"/> when the user exists and has a verified email; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> IsEmailVerifiedAsync(string email) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -233,6 +318,12 @@ public class UsersRepository : RepositoryBase
             return await Connection.ExecuteScalarAsync<bool>(sql, new { Email = email });
         });
 
+    /// <summary>
+    /// Updates mapped user fields for the user with the specified email address.
+    /// </summary>
+    /// <param name="email">Email address of the user to update.</param>
+    /// <param name="model">Model containing fields decorated with database column names.</param>
+    /// <returns><see langword="true"/> when at least one user row is updated; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> UpdateAsync(string email, UpdateUserModel model) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -253,6 +344,12 @@ public class UsersRepository : RepositoryBase
             return await Connection.ExecuteAsync(sql, parameters) != 0;
         });
     
+    /// <summary>
+    /// Adds or replaces the Apple identifier for a user.
+    /// </summary>
+    /// <param name="email">Email address of the user to update.</param>
+    /// <param name="appleId">Apple identifier to store.</param>
+    /// <returns><see langword="true"/> when a non-empty Apple identifier is stored; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> AddAppleIdAsync(string email, string appleId) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -263,6 +360,11 @@ public class UsersRepository : RepositoryBase
             return await Connection.ExecuteAsync(sql, new { AppleId = appleId, Email = email }) != 0;
         });
 
+    /// <summary>
+    /// Deletes the user with the specified email address.
+    /// </summary>
+    /// <param name="email">Email address of the user to delete.</param>
+    /// <returns><see langword="true"/> when the user existed and was deleted; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> DeleteAsync(string email)
     {
         if (!await ExistsAsync(email))
@@ -275,6 +377,10 @@ public class UsersRepository : RepositoryBase
         });
     }
 
+    /// <summary>
+    /// Gets all users.
+    /// </summary>
+    /// <returns>An array of users without password values, or <see langword="null"/> when the query fails.</returns>
     public async Task<User[]?> GetUsers() =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -284,6 +390,12 @@ public class UsersRepository : RepositoryBase
             return users;
         });
 
+    /// <summary>
+    /// Adds or replaces the Google identifier for a user and marks the email as verified.
+    /// </summary>
+    /// <param name="email">Email address of the user to update.</param>
+    /// <param name="googleId">Google identifier to store.</param>
+    /// <returns><see langword="true"/> when a non-empty Google identifier is stored; otherwise, <see langword="false"/>.</returns>
     public async Task<bool> AddGoogleIdAsync(string email, string googleId) =>
         await ExecuteSafelyAsync(async () =>
         {
@@ -294,6 +406,11 @@ public class UsersRepository : RepositoryBase
             return await Connection.ExecuteAsync(sql, new { GoogleId = googleId, Email = email }) != 0;
         });
 
+    /// <summary>
+    /// Gets a user by Google identifier.
+    /// </summary>
+    /// <param name="googleId">Google identifier to load.</param>
+    /// <returns>The matching user, or <see langword="null"/> when the identifier is blank or no user is found.</returns>
     public async Task<User?> GetUserByGoogleId(string googleId) =>
         await ExecuteSafelyAsync(async () =>
         {

--- a/Users/UsersController.cs
+++ b/Users/UsersController.cs
@@ -17,6 +17,7 @@
 using Auth.Services;
 using Email;
 using Repository;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Shared.Extensions;
 using Shared.Logging;
@@ -27,11 +28,24 @@ using Shared.Tools;
 
 namespace Users;
 
+/// <summary>
+/// Provides user profile, account, verification, and profile photo endpoints.
+/// </summary>
 [ApiController]
 [Route("users")]
 public class UsersController : ControllerBase
 {
+    /// <summary>
+    /// Gets all users for an administrator.
+    /// </summary>
+    /// <param name="jwtService">Service used to validate the current JWT.</param>
+    /// <param name="usersRepo">Repository used to check administrator access and load users.</param>
+    /// <returns>An HTTP result containing all users when the caller is an administrator.</returns>
     [HttpGet]
+    [ProducesResponseType(typeof(User[]), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Get([FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo)
     {
@@ -51,7 +65,16 @@ public class UsersController : ControllerBase
         return users is not null ? Ok(users) : StatusCode(500);
     }
 
+    /// <summary>
+    /// Gets the user identifier for the current JWT.
+    /// </summary>
+    /// <param name="jwtService">Service used to validate the current JWT.</param>
+    /// <param name="usersRepo">Repository used to load the current user.</param>
+    /// <returns>An HTTP result containing the current user's identifier.</returns>
     [HttpGet("get-id")]
+    [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> GetId([FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo)
     {
@@ -70,7 +93,17 @@ public class UsersController : ControllerBase
         return Ok(user.Id);
     }
     
+    /// <summary>
+    /// Gets a user by identifier, hiding the email address when the caller is not authorized to view it.
+    /// </summary>
+    /// <param name="userId">Identifier of the user to load.</param>
+    /// <param name="jwtService">Service used to validate an optional JWT.</param>
+    /// <param name="usersRepo">Repository used to load the user and check administrator access.</param>
+    /// <returns>An HTTP result containing the requested user.</returns>
     [HttpGet("{userId:int}")]
+    [ProducesResponseType(typeof(User), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> GetById([FromRoute] int userId,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo)
@@ -103,7 +136,19 @@ public class UsersController : ControllerBase
         return Ok(user);
     }
 
+    /// <summary>
+    /// Updates the specified user when the current JWT belongs to that user or an administrator.
+    /// </summary>
+    /// <param name="userId">Identifier of the user to update.</param>
+    /// <param name="model">User fields to update.</param>
+    /// <param name="jwtService">Service used to validate the current JWT.</param>
+    /// <param name="usersRepo">Repository used to load and update the user.</param>
+    /// <returns>An HTTP result indicating whether the user was updated.</returns>
     [HttpPatch("{userId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> Update([FromRoute] int userId,
         [FromBody] UpdateUserModel model,
         [FromServices] JwtService jwtService,
@@ -131,7 +176,18 @@ public class UsersController : ControllerBase
         return updated ? Ok() : StatusCode(409, "Failed to update user");
     }
 
+    /// <summary>
+    /// Deletes the specified user when the current JWT belongs to that user or an administrator.
+    /// </summary>
+    /// <param name="userId">Identifier of the user to delete.</param>
+    /// <param name="jwtService">Service used to validate the current JWT.</param>
+    /// <param name="usersRepo">Repository used to load and delete the user.</param>
+    /// <returns>An HTTP result indicating whether the user was deleted.</returns>
     [HttpDelete("{userId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> DeleteUser([FromRoute] int userId,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo)
@@ -158,7 +214,18 @@ public class UsersController : ControllerBase
         return deleted ? Ok() : StatusCode(404, "Failed to delete user");
     }
 
+    /// <summary>
+    /// Verifies a user's email address using a verification JWT and redirects to the verification result page.
+    /// </summary>
+    /// <param name="userId">Identifier of the user whose email should be verified.</param>
+    /// <param name="jwt">Verification JWT from the email link.</param>
+    /// <param name="jwtService">Service used to validate the verification JWT.</param>
+    /// <param name="linkGenerator">Service used to build the verification result redirect URL.</param>
+    /// <param name="usersRepo">Repository used to load and verify the user.</param>
+    /// <returns>A permanent redirect to the email verification result page, or an unauthorized response.</returns>
     [HttpGet("{userId:int}/verify-email")]
+    [ProducesResponseType(StatusCodes.Status301MovedPermanently)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> VerifyEmailAsync([FromRoute] int userId,
         [FromQuery] string jwt,
         [FromServices] JwtService jwtService,
@@ -182,7 +249,20 @@ public class UsersController : ControllerBase
         return RedirectPermanent(linkGenerator.GenerateEmailVerificationRedirectionLink(verified));
     }
 
+    /// <summary>
+    /// Changes the password for the specified user.
+    /// </summary>
+    /// <param name="userId">Identifier of the user whose password should be changed.</param>
+    /// <param name="request">Password change request containing the new password.</param>
+    /// <param name="jwtService">Service used to validate the current JWT.</param>
+    /// <param name="usersRepo">Repository used to load the user and change the password.</param>
+    /// <returns>An HTTP result indicating whether the password was changed.</returns>
     [HttpPatch("{userId:int}/change-password")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> ChangePasswordAsync(int userId,
         [FromBody] ChangePasswordRequest request,
         [FromServices] JwtService jwtService,
@@ -218,7 +298,17 @@ public class UsersController : ControllerBase
         return Ok();
     }
 
+    /// <summary>
+    /// Checks whether a user exists by email address or user identifier.
+    /// </summary>
+    /// <param name="userId">Optional user identifier to check.</param>
+    /// <param name="email">Optional email address to check.</param>
+    /// <param name="usersRepo">Repository used to check for a matching user.</param>
+    /// <returns>A conflict result when the user exists, otherwise an OK result.</returns>
     [HttpGet("exists")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> Exists([FromQuery] int? userId,
         [FromQuery] string? email,
         [FromServices] UsersRepository usersRepo)
@@ -235,8 +325,20 @@ public class UsersController : ControllerBase
         return exists ? Conflict("Exists") : Ok();
     }
 
+    /// <summary>
+    /// Uploads or replaces a user's profile photo.
+    /// </summary>
+    /// <param name="userId">Identifier of the user whose photo should be saved.</param>
+    /// <param name="req">Profile photo payload to save.</param>
+    /// <param name="repo">Repository used to save the profile photo.</param>
+    /// <param name="jwtService">Service used to validate the current JWT.</param>
+    /// <returns>An HTTP result indicating whether the profile photo was saved.</returns>
     [HttpPost("{userId:int}/upload-profile-photo")]
     [RequestSizeLimit(130023424)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status409Conflict)]
     public async Task<IActionResult> UploadUserProfilePhoto([FromRoute] int userId,
         [FromBody] UserProfilePhotoModel req,
         [FromServices] PhotosRepository repo,
@@ -257,7 +359,16 @@ public class UsersController : ControllerBase
         return success ? Ok() : Conflict("Failed to save user photo");
     }
 
+    /// <summary>
+    /// Gets a user's profile photo.
+    /// </summary>
+    /// <param name="userId">Identifier of the user whose photo should be loaded.</param>
+    /// <param name="photosRepo">Repository used to load the profile photo.</param>
+    /// <param name="jwtService">Service provided by dependency injection for this endpoint.</param>
+    /// <returns>An HTTP result containing the user's profile photo when one exists.</returns>
     [HttpGet("{userId:int}/get-profile-photo")]
+    [ProducesResponseType(typeof(UserProfilePhotoModel), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetUserProfilePhoto([FromRoute] int userId,
         [FromServices] PhotosRepository photosRepo,
         [FromServices] JwtService jwtService)

--- a/Utils/MapController.cs
+++ b/Utils/MapController.cs
@@ -13,11 +13,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 
 namespace Utils;
 
+/// <summary>
+/// Proxies Mapy.cz API GET requests and injects the configured API key.
+/// </summary>
 [ApiController]
 [Route("map")]
 public class MapController : ControllerBase
@@ -28,8 +32,14 @@ public class MapController : ControllerBase
     {
         _configuration = configuration;
     }
-    
+
+    /// <summary>
+    /// Forwards a GET request path and query string to the Mapy.cz API.
+    /// </summary>
+    /// <param name="path">Catch-all Mapy.cz API path to request.</param>
+    /// <returns>The upstream response stream on success, or the upstream error body with its status code.</returns>
     [HttpGet("{*path}")]
+    [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK)]
     public async Task<IActionResult> ForwardToMapyCz([FromRoute] string path)
     {
         var query = Request.QueryString.Value;

--- a/Utils/UtilsController.cs
+++ b/Utils/UtilsController.cs
@@ -15,6 +15,7 @@
  */
 
 using Auth.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -22,11 +23,15 @@ using System.Text.Json;
 using Repository;
 using Shared.BackgroundServices.AudioProcessing;
 using Shared.Extensions;
+using Shared.Models.Database.Recordings;
 using Shared.Models.Requests.Notifications;
 using Shared.Tools;
 
 namespace Utils;
 
+/// <summary>
+/// Provides maintenance and diagnostic utility endpoints for administrators.
+/// </summary>
 [ApiController]
 [Route("utils")]
 public class UtilsController : ControllerBase
@@ -37,11 +42,26 @@ public class UtilsController : ControllerBase
     {
         _logger = logger;
     }
-    
+
+    /// <summary>
+    /// Checks whether the API process can respond to requests.
+    /// </summary>
+    /// <returns>An empty successful HTTP response.</returns>
     [HttpHead("health")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
     public IActionResult Health() => Ok();
 
+    /// <summary>
+    /// Recalculates recording part end dates when the stored start and end dates are equal.
+    /// </summary>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="usersRepo">Repository used to verify that the authenticated user is an administrator.</param>
+    /// <param name="recordingsRepo">Repository used to repair recording part dates.</param>
+    /// <returns>An HTTP response indicating whether the repair operation was started and completed.</returns>
     [HttpGet("fix-same-dates")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> FixSameDates([FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo,
         [FromServices] RecordingsRepository recordingsRepo)
@@ -61,7 +81,17 @@ public class UtilsController : ControllerBase
         return Ok();
     }
 
+    /// <summary>
+    /// Normalizes stored audio files for existing recording parts.
+    /// </summary>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="usersRepo">Repository used to verify that the authenticated user is an administrator.</param>
+    /// <param name="recordingsRepo">Repository used to normalize recording part audio files.</param>
+    /// <returns>An HTTP response indicating whether the normalization operation was started and completed.</returns>
     [HttpGet("normalize-existing-audios")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> NormalizeExistingAudios([FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo,
         [FromServices] RecordingsRepository recordingsRepo)
@@ -80,8 +110,18 @@ public class UtilsController : ControllerBase
         await recordingsRepo.NormalizeAudiosAsync();
         return Ok();
     }
-    
+
+    /// <summary>
+    /// Logs detected format and duration information for stored recording part audio files.
+    /// </summary>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="usersRepo">Repository used to verify that the authenticated user is an administrator.</param>
+    /// <param name="recordingsRepo">Repository used to inspect recording part audio files.</param>
+    /// <returns>An HTTP response indicating whether the analysis operation was started and completed.</returns>
     [HttpGet("analyze-parts")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> AnalyzeParts([FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo,
         [FromServices] RecordingsRepository recordingsRepo)
@@ -101,7 +141,20 @@ public class UtilsController : ControllerBase
         return Ok();
     }
 
+    /// <summary>
+    /// Sends a custom invisible Firebase notification to every device registered for a user.
+    /// </summary>
+    /// <param name="req">Notification payload and target user identifier.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="usersRepo">Repository used to verify that the authenticated user is an administrator.</param>
+    /// <param name="devicesRepo">Repository used to load the target user's devices.</param>
+    /// <param name="notificationService">Service used to send Firebase notifications.</param>
+    /// <returns>An HTTP response indicating whether the notification dispatch loop completed.</returns>
     [HttpPost("send-notification")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> SendNotification([FromBody] SendNotificationRequest req,
         [FromServices] JwtService jwtService,
         [FromServices] UsersRepository usersRepo,
@@ -148,7 +201,20 @@ public class UtilsController : ControllerBase
         return Ok();
     }
 
+    /// <summary>
+    /// Queues audio classification work for recordings that have not yet produced classified filtered parts.
+    /// </summary>
+    /// <param name="queue">Background queue used to run audio processing work.</param>
+    /// <param name="recordingsRepo">Repository used to load recordings and store prediction results.</param>
+    /// <param name="jwtService">Service used to validate the bearer JWT.</param>
+    /// <param name="usersRepo">Repository used to verify that the authenticated user is an administrator.</param>
+    /// <returns>An HTTP response containing the recordings queued for classification, or an error status.</returns>
     [HttpGet("classify")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(Recording[]), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
     public async Task<IActionResult> ClassifyRecordings([FromServices] AudioProcessingQueue queue, 
         [FromServices] RecordingsRepository recordingsRepo, 
         [FromServices] JwtService jwtService,


### PR DESCRIPTION
## Summary
- Added XML documentation and response metadata across controller/repository pairs so endpoint behavior is described from code
- Enabled solution-wide XML doc generation and switched Host to build OpenAPI from Swashbuckle instead of the embedded static YAML
- Kept the existing `/swagger/v1/swagger.json` and YAML export routes, but now they are generated from the annotated API surface

## Testing
- `dotnet build StrnadiAPI.sln --no-restore -m:1 -nodeReuse:false -p:UseSharedCompilation=false` passed
- Verified XML documentation files are emitted for the project assemblies